### PR TITLE
design (phase 1): token scales + fix 4 theming bugs

### DIFF
--- a/src/components/Body/Body.module.css
+++ b/src/components/Body/Body.module.css
@@ -16,7 +16,7 @@
   flex-direction: column;
   align-items: center;
 
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
 
   transition: opacity calc(6 * var(--transition-speed-c6dbf459)) ease-in-out;
 }
@@ -75,7 +75,7 @@
 }
 
 .tight {
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
 }
 
 .lowScoreContainer {
@@ -101,17 +101,17 @@
 }
 
 .smallHeading {
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 24px;
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  line-height: 24px; /* TODO(tokens): line-height scale (24px = 1.5 * 16) */
   width: 100%;
 }
 
 .heading {
   text-align: left;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 16px;
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
   width: 100%;
 }
 
@@ -148,15 +148,15 @@
     calc(0.5 * var(--widget-padding-x-c6dbf459));
   background: rgba(var(--color-secondary-c6dbf459), 1);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-lg-c6dbf459);
   cursor: pointer;
   transition: all var(--transition-speed-c6dbf459) ease;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2-c6dbf459);
   color: rgba(var(--color-primary-c6dbf459), 1);
 }
 
 .platformButtonContents {
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
   display: flex;
   align-items: center;
   width: 100%;
@@ -194,7 +194,7 @@
   flex: 1;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
 }
 
 .platformIcon {
@@ -284,7 +284,7 @@
 .navigationButtons {
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
   align-items: center;
   width: 100%;
 }
@@ -292,8 +292,8 @@
 .dedupeBadge {
   background-color: rgb(var(--color-secondary-c6dbf459));
   padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 10px;
+  border-radius: var(--radius-sm-c6dbf459);
+  font-size: 10px; /* TODO(tokens): sub-xs size not in scale */
   color: rgb(var(--color-primary-c6dbf459));
   font-weight: 500;
   text-transform: uppercase;
@@ -311,7 +311,11 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  color: rgb(var(--color-secondary-c6dbf459));
+  /* On-surface @ 0.7 alpha instead of full `secondary`. secondary is really a
+   * muted-SURFACE token (buttons/borders/badges); using it as text failed AA
+   * in LightTheme (200,200,200 on white ~= 1.7:1). primary @ 0.7 clears 4.5:1
+   * in both themes. */
+  color: rgba(var(--color-primary-c6dbf459), 0.7);
 }
 
 .footerText {
@@ -325,7 +329,8 @@
   align-items: center;
   width: 56px;
   height: 56px;
-  color: white;
+  /* On-surface color: was `white`, invisible on the LightTheme white surface. */
+  color: rgb(var(--on-surface));
   position: relative;
   z-index: 1; /* Above blur effect */
   flex-shrink: 0;
@@ -348,7 +353,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
 }
 
 .closeIcon {
@@ -379,8 +384,9 @@
 }
 
 .loadingText {
-  margin-top: 8px;
-  color: rgb(var(--color-secondary-c6dbf459));
+  margin-top: var(--space-2-c6dbf459);
+  /* On-surface @ 0.7 (was full `secondary`) so it clears AA in both themes. */
+  color: rgba(var(--color-primary-c6dbf459), 0.7);
   text-align: center;
   flex-grow: 1;
 }
@@ -415,7 +421,7 @@
 .stampCategory {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
   padding-top: var(--widget-padding-y-c6dbf459);
 }
 
@@ -456,7 +462,7 @@
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
 }
 
 .exploreMoreLink svg {
@@ -532,9 +538,9 @@
   align-items: center;
   justify-content: center;
   background-color: rgba(var(--color-primary-c6dbf459), 0.1);
-  font-weight: 600;
+  font-weight: var(--weight-semibold-c6dbf459);
   padding: 1px;
-  border-radius: 6px;
+  border-radius: var(--radius-md-c6dbf459);
   min-width: 32px;
 }
 
@@ -550,7 +556,7 @@
 .errorSubHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
   align-self: self-start;
   font-weight: 600;
   width: 100%;
@@ -562,7 +568,7 @@
   align-items: center;
   width: 100%;
   height: 100%;
-  gap: 8px;
+  gap: var(--space-2-c6dbf459);
   padding: 0;
 }
 

--- a/src/components/Tooltip.module.css
+++ b/src/components/Tooltip.module.css
@@ -9,19 +9,18 @@
   top: 0;
   left: 0;
   z-index: 9999;
-  padding: 12px 16px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: #e5e7eb;
-  background-color: #1f2937;
-  border: 1px solid #374151;
-  border-radius: 8px;
-  box-shadow:
-    0 20px 25px -5px rgba(0, 0, 0, 0.25),
-    0 10px 10px -5px rgba(0, 0, 0, 0.15);
+  padding: var(--space-3-c6dbf459) var(--space-4-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  /* Theme-driven: reads correctly in both light and dark themes. */
+  color: rgb(var(--on-surface));
+  background-color: rgb(var(--surface));
+  border: 1px solid rgba(var(--border), 1);
+  border-radius: var(--radius-lg-c6dbf459);
+  box-shadow: var(--shadow-md-c6dbf459);
   max-width: 320px;
   pointer-events: none;
-  animation: fadeIn 200ms ease-in;
+  animation: fadeIn var(--motion-base-c6dbf459) ease-in;
 }
 
 .content {
@@ -33,8 +32,8 @@
   position: absolute;
   width: 8px;
   height: 8px;
-  background-color: #1f2937;
-  border: 1px solid #374151;
+  background-color: rgb(var(--surface));
+  border: 1px solid rgba(var(--border), 1);
   transform: rotate(45deg);
   z-index: 0;
 }

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -42,6 +42,8 @@ export const LightTheme: PassportWidgetTheme = {
     secondary: "200, 200, 200",
     background: "255, 255, 255",
     accent: "113, 248, 194",
-    error: "55, 55, 55",
+    // Real error red, legible on the light (white) surface. Previously 55,55,55
+    // (grey) which disagreed with the DarkTheme error and read as non-error.
+    error: "220, 38, 38",
   },
 };

--- a/src/widgets/Widget.module.css
+++ b/src/widgets/Widget.module.css
@@ -9,7 +9,11 @@
   --color-primary-c6dbf459: 255, 255, 255;
   --color-secondary-c6dbf459: 109, 109, 109;
   --color-background-c6dbf459: 0, 0, 0;
-  --color-error-c6dbf459: 203, 203, 203;
+  /* Default accent (matches DarkTheme). Seeded so role aliases + blur/accent
+   * usages resolve even when no theme prop is supplied. */
+  --color-accent-c6dbf459: 0, 212, 170;
+  /* Sane default error color (red-ish), not grey. Both themes override this. */
+  --color-error-c6dbf459: 220, 38, 38;
   --color-white-c6dbf459: 255, 255, 255;
   --color-black-c6dbf459: 0, 0, 0;
   --widget-padding-x-c6dbf459: 20px;
@@ -27,6 +31,71 @@
     "Suisse Intl", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     sans-serif;
   --position-overlay-z-index-c6dbf459: 10;
+
+  /* ---------------------------------------------------------------------
+   * Design token scales (§1). Primitives seeded here so the whole widget
+   * shares one source of truth. These are static (non-theme) tokens; the
+   * per-role color aliases below map onto the theme-driven color vars.
+   * ------------------------------------------------------------------- */
+
+  /* Spacing scale: 0 / 4 / 8 / 12 / 16 / 24 / 32 / 48 */
+  --space-0-c6dbf459: 0;
+  --space-1-c6dbf459: 4px;
+  --space-2-c6dbf459: 8px;
+  --space-3-c6dbf459: 12px;
+  --space-4-c6dbf459: 16px;
+  --space-5-c6dbf459: 24px;
+  --space-6-c6dbf459: 32px;
+  --space-7-c6dbf459: 48px;
+
+  /* Type scale */
+  --font-size-xs-c6dbf459: 12px;
+  --font-size-sm-c6dbf459: 13px;
+  --font-size-md-c6dbf459: 14px;
+  --font-size-lg-c6dbf459: 16px;
+  --font-size-xl-c6dbf459: 20px;
+
+  --line-tight-c6dbf459: 1;
+  --line-normal-c6dbf459: 1.5;
+  --line-relaxed-c6dbf459: 1.7;
+
+  --weight-regular-c6dbf459: 400;
+  --weight-medium-c6dbf459: 500;
+  --weight-semibold-c6dbf459: 600;
+  --weight-bold-c6dbf459: 700;
+
+  /* Radius scale */
+  --radius-sm-c6dbf459: 4px;
+  --radius-md-c6dbf459: 6px;
+  --radius-lg-c6dbf459: 8px;
+  --radius-pill-c6dbf459: 999px;
+
+  /* Elevation */
+  --shadow-sm-c6dbf459: 0 1px 2px rgba(0, 0, 0, 0.12);
+  --shadow-md-c6dbf459:
+    0 20px 25px -5px rgba(0, 0, 0, 0.25),
+    0 10px 10px -5px rgba(0, 0, 0, 0.15);
+
+  /* Motion */
+  --motion-fast-c6dbf459: 50ms;
+  --motion-base-c6dbf459: 200ms;
+  --ease-standard-c6dbf459: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ---------------------------------------------------------------------
+   * Per-role color aliases. Future work overrides ONE semantic name and it
+   * flows everywhere. Each maps onto an existing theme-driven color var, so
+   * setTheme() keeps controlling the real values and nothing breaks.
+   * (Declared on .widget so they always shadow any host-page var of the
+   * same name — collision-safe without needing the -c6dbf459 postfix.)
+   * ------------------------------------------------------------------- */
+  --surface: var(--color-background-c6dbf459);
+  --on-surface: var(--color-primary-c6dbf459);
+  --muted: var(--color-secondary-c6dbf459);
+  --accent: var(--color-accent-c6dbf459);
+  --on-accent: var(--color-black-c6dbf459);
+  --danger: var(--color-error-c6dbf459);
+  --on-danger: var(--color-white-c6dbf459);
+  --border: var(--color-secondary-c6dbf459);
 
   /* Width will be 300 unless screen
    * is too narrow, in which case it


### PR DESCRIPTION
First modernization phase — establishes the **design-token layer** the restyle needs and fixes the **theming bugs** from the design audit. Everything is verifiable by toggling the light/dark stories in the Storybook (#80, this PR's base).

**Theming bugs fixed**
- **Tooltip** ignored the theme (hardcoded light-grey) → themes via `--on-surface`/`--surface`/`--border`; correct in both themes.
- `.iconContainer` `color:white` → invisible on LightTheme → `--on-surface` (**11.9:1** on light).
- **Error color** unified — the three disagreeing sources (grey seed / grey LightTheme / red DarkTheme) collapse onto one `--danger` token; a theme lacking `error` now falls back to a real red.
- **Low-contrast secondary text** — footer/loadingText moved to `primary@0.7` → clears **4.5:1** in both themes (was 1.67:1 light / 4.06:1 dark).

**Token scales added** (seeded on `.widget`): `--space-0..7`, `--font-size-{xs..xl}` + `--line-*`, `--weight-*`, `--radius-*`, `--shadow-*`, `--motion-*` + `--ease-standard`, and per-role color aliases (`--surface`/`--on-surface`/`--muted`/`--accent`/`--danger`/`--border`) mapping onto the existing color vars (so `setTheme()` still drives values). Migrated the low-risk radius/heading/gap usages; sub-scale sizes + odd paddings left as `TODO(tokens)` for the type/spacing phase.

Rules: [products/passport/embed/design-sop.md](https://github.com/holonym-foundation/internal-docs/pull/1884) §1 (tokens) + §2 (theming). `yarn build-storybook` passes. Only 4 files (CSS + themes.ts).