### PR TITLE
redesign slice 3: Stamp detail drawer

### DIFF
--- a/src/redesign/PassportShell.module.css
+++ b/src/redesign/PassportShell.module.css
@@ -1,0 +1,740 @@
+/*
+ * PassportShell - the rounded binding. Everything lives INSIDE these bounds.
+ * All color/size/motion comes from the widget's shared tokens (§1); no magic
+ * numbers, no theme-specific literals (§2). No backdrop-filter/transform on any
+ * ancestor of a tooltip trigger, so the portal-style Tooltip (position:fixed)
+ * is never trapped in a containing block and never clips (§4 overlay layering).
+ */
+
+.shell {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-4-c6dbf459);
+  border-radius: var(--widget-radius-c6dbf459);
+  background: rgb(var(--surface));
+  /* No hard line: the shell reads as its own lifted surface via layered shadow +
+   * the wash, not a 1px outline. The edge tokens add a hairline light inner rim
+   * and a soft ambient outer glow so a near-black widget separates from a DARK
+   * host (§no-hard-lines); --shadow-md carries the depth on a light host. */
+  box-shadow:
+    var(--rd-edge-rim),
+    var(--rd-edge-glow),
+    var(--shadow-md-c6dbf459);
+  color: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  /* content + overlays escape; only the decorative .fx is clipped */
+  overflow: visible;
+}
+
+/* Decorative living-material wash: a subtle emerald paper-shader field. Its color
+ * is the integrator-configurable --rd-wash token (defaults to the accent). A
+ * SIBLING layer (not an ancestor of any trigger), clipped to the rounded bounds.
+ * A lightweight animated gradient drift stands in for a full canvas paper-shader.
+ * Legibility first: kept low-alpha and behind all content. */
+.fx {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  /* Alphas raised so the soft emerald wash actually reads on the brand dark
+   * surface (#101815), while staying subtle on the light (white) surface. */
+  background:
+    radial-gradient(120% 80% at 85% -10%, rgba(var(--rd-wash), 0.24), transparent 60%),
+    radial-gradient(95% 75% at -12% 112%, rgba(var(--rd-wash), 0.16), transparent 55%),
+    radial-gradient(70% 60% at 50% 40%, rgba(var(--rd-wash), 0.07), transparent 70%);
+  background-size: 160% 160%, 170% 170%, 200% 200%;
+  animation: washDrift 18s ease-in-out infinite alternate;
+}
+@keyframes washDrift {
+  0% {
+    background-position: 0% 0%, 100% 100%, 50% 50%;
+  }
+  100% {
+    background-position: 12% 8%, 88% 92%, 46% 54%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fx {
+    animation: none;
+  }
+}
+
+/* ---- size variants: one standard shell height across states (§ structure) ---- */
+/* `full` gives the content region a FIXED height so the default score, account,
+ * and drill-down states share one shell height AND so the window's bottom-pinned
+ * action area lands the primary CTA at the same coordinates in every state. */
+.full .content {
+  /* Tall enough for the busiest state (below-threshold: ring + headline + sub +
+   * to-go + TWO stacked CTAs) with headroom, so nothing clips and the auto gap
+   * has room to push the action area to the bottom in every state. */
+  height: 384px;
+}
+/* mini is a condensed ~half-size card; pill is a single compact row. Both are
+ * fixed-height for the same pin-the-CTA reason. */
+.mini .content {
+  height: 192px;
+}
+.pill,
+.mini {
+  padding: var(--space-3-c6dbf459);
+}
+/* The pill carries NO chrome and NO footer: the whole widget is one short row.
+ * The content region is exactly the ring-height row, vertically centered, with
+ * no top margin (there is no chrome above it to clear). */
+.pill .content {
+  height: 44px;
+  margin-top: 0;
+  justify-content: center;
+}
+
+.shell > *:not(.fx) {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---- chrome row: app-icon · account · ⓘ ---- */
+/* position:relative so the account dropdown anchors to the chrome row, which
+ * spans the shell's content box - letting the menu pin left:0 / right:0 and
+ * stay inside the shell at ANY widget width. */
+.chrome {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+}
+
+/* The chrome row (and the account dropdown it contains) must outrank the score
+ * content below it, or the ring - a later `.shell > *` at the same z-index -  * paints over the open menu. Higher-specificity + later-in-file than the shared
+ * `.shell > *:not(.fx)` rule, so it wins without !important. */
+.shell > .chrome {
+  z-index: 3;
+}
+
+.gl {
+  display: block;
+}
+
+.appIcon {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-lg-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-surface));
+  /* Tonal fill, no hard outline. */
+  background: rgba(var(--on-surface), 0.06);
+  cursor: help;
+}
+/* Invisible ≥40px hit target (a11y §8): 34px + 2×4px = 42px. Visual size unchanged. */
+.appIcon::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+}
+.appIcon:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+/* ---- account selector ---- */
+/* NOT positioned: the menu anchors to .chrome (the content-box-wide row) so it
+ * spans the shell width instead of the narrow trigger. */
+.acctWrap {
+  min-width: 0;
+  margin-right: auto;
+}
+
+.acct {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  margin: 0;
+  padding: var(--space-1-c6dbf459) var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: var(--line-tight-c6dbf459);
+  min-width: 0;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+  font-family: inherit;
+}
+.acct:hover {
+  background: rgba(var(--on-surface), 0.05);
+}
+.acct:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 1px;
+}
+
+.acctLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.7);
+  transform: scale(0.82);
+  transform-origin: left center;
+}
+
+.acctWho {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.acctName {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.acctOf {
+  font-weight: var(--weight-regular-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+}
+
+.acctCaret {
+  flex: none;
+  color: rgba(var(--on-surface), 0.6);
+  transition: transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.acctOpen .acctCaret {
+  transform: rotate(180deg);
+}
+
+/* dropdown: TOP z-index, near-opaque backdrop, never clipped and NEVER outside
+ * the shell (§ overlay layering). It spans the shell's content box: pulled left
+ * past the account trigger to the shell content's left edge (the app-icon start
+ * = appIcon width 34px + the chrome gap) and sized to the content width, so its
+ * right edge lands on the content edge instead of overflowing the rounded bound.
+ * Fades (opacity), collapses instantly under reduced-motion below. */
+.menu {
+  position: absolute;
+  box-sizing: border-box;
+  top: calc(100% + var(--space-1-c6dbf459));
+  left: 0;
+  right: 0;
+  z-index: 400;
+  padding: var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  /* Elevated, near-opaque glass: lifts off the shell as a distinct layer in BOTH
+   * themes (darkens slightly on white, lightens slightly on near-black), never
+   * black-on-black. High-alpha surface so the content behind never bleeds
+   * through; blur + shadow carry the separation instead of a hard border. */
+  background:
+    linear-gradient(rgba(var(--on-surface), 0.08), rgba(var(--on-surface), 0.08)),
+    rgba(var(--surface), 0.98);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  backdrop-filter: blur(14px) saturate(1.2);
+  box-shadow:
+    var(--shadow-md-c6dbf459),
+    inset 0 0 0 1px rgba(var(--on-surface), 0.06);
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top left;
+  pointer-events: none;
+  transition:
+    opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.acctOpen .menu {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+/* Small uppercase zone label. */
+.zoneHead {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.6);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+}
+
+/* Zones are separated by SPACE and a faint tonal band, never a hard line. */
+.zoneMid {
+  margin-top: var(--space-1-c6dbf459);
+  padding-top: var(--space-1-c6dbf459);
+}
+.zoneBottom {
+  margin-top: var(--space-1-c6dbf459);
+  padding-top: var(--space-1-c6dbf459);
+}
+
+/* (a) top: the WaaP account behind the passport. */
+.zoneTop {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: rgba(var(--on-surface), 0.05);
+}
+.waapMark {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-md-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-accent));
+  background: linear-gradient(135deg, rgb(var(--accent)), rgba(var(--accent), 0.55));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+.waapMeta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 1px;
+}
+.waapName {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.waapLine {
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.75);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Address line holds the truncating address plus the hover-to-copy control. */
+.waapAddrRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.waapAddr {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  color: rgba(var(--on-surface), 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* ---- hover-to-copy control (account address + linked wallet rows) ---- */
+/* Hidden until the row is hovered or the button is focused (keyboard-reachable),
+ * but always laid out so revealing it never shifts the row. On copy it swaps to
+ * a check + "Copied" and stays visible for the ~1.5s confirmation window. */
+.copyBtn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 6px;
+  border: 0;
+  border-radius: var(--radius-sm-c6dbf459);
+  background: transparent;
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  opacity: 0;
+  transition:
+    opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.zoneTop:hover .copyBtn,
+.walletRow:hover .copyBtn,
+.copyBtn:focus-visible {
+  opacity: 1;
+}
+.copyBtn:hover {
+  background: rgba(var(--accent), 0.12);
+  color: rgb(var(--on-surface));
+}
+.copyBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+/* Confirmed state: stays visible (even without hover) while "Copied" shows. */
+.copyBtnDone,
+.copyBtnDone:hover {
+  opacity: 1;
+  color: rgb(var(--accent));
+  background: rgba(var(--accent), 0.12);
+}
+.copyGlyph {
+  display: inline-flex;
+}
+.copyText {
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copyBtn {
+    transition: none;
+  }
+}
+
+/* (b) middle: linked wallet rows + link-additional CTA. */
+.walletRow {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+}
+.walletIcon {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-sm-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.8);
+  background: rgba(var(--on-surface), 0.06);
+}
+.walletMeta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+.walletName {
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.walletReason {
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.walletKind {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.66);
+}
+
+/* A wallet in cooldown / pending: dimmed row + an amber status pill with a short
+ * plain reason line. It reads as "not usable yet", never a hard failure. */
+.walletRowMuted .walletName {
+  color: rgba(var(--on-surface), 0.72);
+}
+.walletRowMuted .walletIcon {
+  opacity: 0.7;
+}
+.walletStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  padding: 2px 7px;
+  border-radius: var(--radius-pill-c6dbf459);
+  color: rgb(var(--warn));
+  background: rgba(var(--warn), 0.15);
+}
+
+/* Unlink control: hidden until the row is hovered or the button is focused, but
+ * always present in the layout (no shift) and keyboard-reachable. */
+.unlinkBtn {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.walletRow:hover .unlinkBtn,
+.unlinkBtn:focus-visible {
+  opacity: 1;
+}
+.unlinkBtn:hover {
+  background: rgba(var(--danger), 0.14);
+  color: rgb(var(--danger));
+}
+.unlinkBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+
+/* Pagination for >3 linked wallets: dots + arrows, NEVER a scrollbar (§ never
+ * scroll). */
+.walletPager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459) 0;
+}
+.pagerArrow {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.zoneEmpty {
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+}
+.linkWalletBtn {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  margin-top: var(--space-1-c6dbf459);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  background: rgba(var(--accent), 0.12);
+  color: rgb(var(--on-surface));
+  font-family: inherit;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.linkWalletBtn:hover {
+  background: rgba(var(--accent), 0.2);
+}
+.linkWalletBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.linkWalletBtn svg {
+  color: rgb(var(--accent));
+}
+
+/* (c) bottom: switch accounts + sign out. */
+.switchGroup {
+  margin-bottom: var(--space-1-c6dbf459);
+}
+.signOut {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  background: transparent;
+  color: rgba(var(--on-surface), 0.8);
+  font-family: inherit;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.signOut:hover {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+}
+.signOut:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+
+.menuItem {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+}
+.menuItem:hover {
+  background: rgba(var(--on-surface), 0.07);
+}
+.menuItem:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.menuItemOn {
+  background: rgba(var(--accent), 0.16);
+}
+.menuItemOn:hover {
+  background: rgba(var(--accent), 0.22);
+}
+
+.menuAvatar {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: var(--radius-md-c6dbf459);
+  background: linear-gradient(135deg, rgb(var(--accent)), rgba(var(--accent), 0.45));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.menuName {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menuKind {
+  margin-left: auto;
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.72);
+}
+
+/* ---- ⓘ help ---- */
+.info {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.72);
+  background: rgba(var(--on-surface), 0.05);
+  cursor: help;
+}
+/* Invisible ≥40px hit target (a11y §8): 22px + 2×9px = 40px. Visual size unchanged. */
+.info::before {
+  content: "";
+  position: absolute;
+  inset: -9px;
+}
+.info:hover {
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.1);
+}
+.info:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- content window ---- */
+.content {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--space-3-c6dbf459);
+}
+
+/* Footer lives in the shared SecuredByFooter component (§ harmonized footer). */
+
+@media (prefers-reduced-motion: reduce) {
+  .menu,
+  .acctCaret {
+    transition: none;
+  }
+}

--- a/src/redesign/PassportShell.stories.tsx
+++ b/src/redesign/PassportShell.stories.tsx
@@ -1,0 +1,455 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { PassportShell } from "./PassportShell";
+import { ScoreWindow } from "./ScoreWindow";
+import { Widget } from "../widgets/Widget";
+import { LightTheme } from "../utils/themes";
+import {
+  ThemePair,
+  SAMPLE_ACCOUNT,
+  ACCOUNT_ONE_WALLET,
+  ACCOUNT_THREE_WALLETS,
+  ACCOUNT_SIX_WALLETS,
+  ACCOUNT_COOLDOWN,
+} from "./storyFrame";
+
+/**
+ * PassportShell - the chrome binding: app-icon slot · account menu · ⓘ · the
+ * shared "Secured by human.tech" footer, all INSIDE the rounded bounds. No hard
+ * lines. Rendered in both themes on matching host backgrounds.
+ */
+const meta: Meta<typeof PassportShell> = {
+  title: "Redesign/Shell",
+  component: PassportShell,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof PassportShell>;
+
+/** A stand-in for an integrator's own brand mark, passed via the appIcon prop. */
+const SampleAppIcon = (
+  <span
+    style={{
+      display: "grid",
+      placeItems: "center",
+      width: 20,
+      height: 20,
+      borderRadius: 5,
+      background: "linear-gradient(135deg, #7c3aed, #4f46e5)",
+      color: "#fff",
+      fontWeight: 700,
+      fontSize: 12,
+    }}
+  >
+    A
+  </span>
+);
+
+export const Default: Story = {
+  name: "Shell / Default (no app-icon)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default: NO app-icon. The slot renders nothing (no placeholder box) and the header leads with the 'Shady.eth's Passport ▾' account selector, then the ⓘ help affordance, all inside the rounded shell. Hover the ⓘ for a glass tooltip (edge-aware, never clipped). Note the soft light edge separating the widget from the host background, clearest on the dark host.",
+      },
+    },
+  },
+};
+
+export const AppIconTooltip: Story = {
+  name: "Shell / With integrator app-icon",
+  render: () => (
+    <ThemePair>
+      <PassportShell
+        account={SAMPLE_ACCOUNT}
+        appIcon={SampleAppIcon}
+        appIconTooltip="Verify with Acme to keep your account in good standing."
+      >
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        // The explanatory sentence lives HERE (dev documentation), never in the
+        // shipped component. It is the app-icon's tooltip only because the
+        // integrator supplied it via appIconTooltip.
+        story:
+          "When the integrator passes appIcon, their own product icon leads the header (here a sample 'Acme' mark). It is their brand, not ours, so the component ships no explanatory tooltip of its own. It renders one only when the integrator also supplies appIconTooltip, shown here with sample integrator copy.",
+      },
+    },
+  },
+};
+
+export const AccountMenuOpen: Story = {
+  name: "Shell / Account menu open (three zones)",
+  render: () => (
+    <ThemePair>
+      <PassportShell
+        account={SAMPLE_ACCOUNT}
+        defaultAccountMenuOpen
+        onLinkWallet={() => undefined}
+        onUnlinkWallet={() => undefined}
+        onSignOut={() => undefined}
+      >
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The account menu in three zones. Top: the WaaP account behind the passport (mark + name + email + address). Middle: linked wallets plus a 'Link additional wallet' CTA. Bottom: switch accounts and sign out. Left-aligned, near-opaque glass, top z-index, contained within the shell.",
+      },
+    },
+  },
+};
+
+export const OneLinkedWallet: Story = {
+  name: "Shell / Wallets: one linked",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_ONE_WALLET} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "A single linked wallet. Hover the row (or tab to it) to reveal the unlink control. No pager." },
+    },
+  },
+};
+
+export const ThreeLinkedWallets: Story = {
+  name: "Shell / Wallets: three linked",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_THREE_WALLETS} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Three wallets fill one page exactly, so no pager appears. Each row exposes an unlink control on hover / focus." },
+    },
+  },
+};
+
+export const SixLinkedWallets: Story = {
+  name: "Shell / Wallets: six linked (paginated)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_SIX_WALLETS} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "More than three wallets paginate into pages of three with dots and arrows. There is never a scrollbar (SOP never-scroll rule). Arrows and dots are keyboard-reachable.",
+      },
+    },
+  },
+};
+
+export const WalletCooldown: Story = {
+  name: "Shell / Wallets: cooldown + pending",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_COOLDOWN} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A wallet in cooldown and one still pending each render a dimmed row with an amber status pill and a short plain reason. Pending wallets are not yet unlinkable; cooldown wallets still expose unlink.",
+      },
+    },
+  },
+};
+
+export const NoAccount: Story = {
+  name: "Shell / Without account selector",
+  render: () => (
+    <ThemePair>
+      <PassportShell>
+        <ScoreWindow state="below" score={12} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Integrator supplies no account identity, so the selector collapses and the chrome stays balanced (app-icon + ⓘ).",
+      },
+    },
+  },
+};
+
+export const HiddenAccountSelector: Story = {
+  name: "Shell / Account selector hidden (accountSelector=false)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} appIcon={SampleAppIcon} accountSelector={false}>
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The accountSelector={false} customization knob hides the account selector from the header even though an account is supplied. The header leads with the integrator's app-icon (or nothing when no app-icon is given), then the ⓘ. Use this when the integrator drives identity in their own chrome.",
+      },
+    },
+  },
+};
+
+export const CopyOnHover: Story = {
+  name: "Shell / Copy address on hover",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Hover (or tab to) the passport account address and any linked wallet row to reveal a small copy control. Clicking copies the FULL address to the clipboard (the rows show a truncated form) and briefly shows a check + 'Copied', reverting after ~1.5s. Keyboard-reachable.",
+      },
+    },
+  },
+};
+
+export const CustomWash: Story = {
+  name: "Shell / Integrator wash color",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} washRgb="139, 92, 246">
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The paper-shader wash is integrator-configurable via the washRgb prop (an r, g, b triplet). Here a violet wash replaces the default emerald, while the ring / CTA accent stays on the theme.",
+      },
+    },
+  },
+};
+
+export const PillVariant: Story = {
+  name: "Shell / Size variant: pill",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          onContinue={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The compact 'pill' size: one true single row. The score ring stands in for the app-icon at the left (showing the score, e.g. 24), then the account name / short address preview, then a narrow Continue action, all on the same pill-height row. No app-icon, no ⓘ, no 'Verified' word, and no footer. The only tooltip is the score-hover on the ring. Clearly distinct from mini and full.",
+      },
+    },
+  },
+};
+
+export const PillLoading: Story = {
+  name: "Shell / Pill: loading",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow size="pill" state="loading" />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill loading state: a small loader stands in for the ring plus a short label, all on the one pill row, with the compact 'Secured by human.tech' lockup beneath.",
+      },
+    },
+  },
+};
+
+export const PillBelow: Story = {
+  name: "Shell / Pill: below threshold",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="below"
+          score={17}
+          threshold={20}
+          addVerificationsCta={{ onClick: () => undefined }}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill below-threshold state: the small amber ring, a 'N to go' label, and one compact 'Verify' action, kept to a single short row.",
+      },
+    },
+  },
+};
+
+export const PillVerified: Story = {
+  name: "Shell / Pill: verified",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          onContinue={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill verified state: the completed emerald ring, the account preview, and a compact Continue hand-off, all on one row.",
+      },
+    },
+  },
+};
+
+export const PillError: Story = {
+  name: "Shell / Pill: error",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow size="pill" state="error" errorKind="network" onRetry={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill error state: a compact danger mark, the short humanized title (never a raw error message), and a compact Retry, all on one row.",
+      },
+    },
+  },
+};
+
+export const PillStatusOnly: Story = {
+  name: "Shell / Pill: verified, no action (showAction=false)",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          showAction={false}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The button on/off option: showAction={false} renders a status-only pill with no action button, just the score ring and the account preview. The integrator drives any hand-off in their own UI.",
+      },
+    },
+  },
+};
+
+export const MiniVariant: Story = {
+  name: "Shell / Size variant: mini",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="mini" account={SAMPLE_ACCOUNT}>
+        <ScoreWindow size="mini" state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The 'mini' size: a condensed roughly half-height card with a smaller ring, tighter spacing, and a single action. In the verified state the 'You're verified' line folds INTO the CTA (check + 'You're verified', which continues on tap) to save vertical space: ring + that one button + footer, no standalone verified line. Distinct from the single-row pill and the full card.",
+      },
+    },
+  },
+};
+
+export const SizeComparison: Story = {
+  name: "Shell / All three sizes",
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: 28,
+        flexWrap: "wrap",
+        alignItems: "flex-start",
+        padding: 24,
+        borderRadius: 20,
+        background: "#eef0f4",
+      }}
+    >
+      {(["full", "mini", "pill"] as const).map((s) => (
+        <div key={s} style={{ width: 300 }}>
+          <Widget theme={LightTheme}>
+            <PassportShell size={s} account={s === "pill" ? undefined : SAMPLE_ACCOUNT}>
+              <ScoreWindow
+                size={s}
+                state="verified"
+                score={24}
+                threshold={20}
+                accountPreview={s === "pill" ? SAMPLE_ACCOUNT.display : undefined}
+                onContinue={() => undefined}
+              />
+            </PassportShell>
+          </Widget>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "full, mini, and pill side by side so the three variants visibly differ in size and layout." },
+    },
+  },
+};

--- a/src/redesign/PassportShell.tsx
+++ b/src/redesign/PassportShell.tsx
@@ -1,0 +1,505 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./PassportShell.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import {
+  CaretDownIcon,
+  CheckIcon,
+  ClockIcon,
+  CopyIcon,
+  InfoIcon,
+  LogoutIcon,
+  PlusIcon,
+  SwitchIcon,
+  UnlinkIcon,
+  WaaPIcon,
+  WalletIcon,
+} from "./icons";
+import { SecuredByFooter } from "./SecuredByFooter";
+
+export type ShellAccountOption = {
+  /** Display name, e.g. "Shady.eth" or "0x1332…4a9f". */
+  display: string;
+  /** Short kind label, e.g. "ENS" / "Wallet". */
+  kind?: string;
+};
+
+/** Linking status of a wallet on the passport. */
+export type LinkedWalletStatus = "active" | "cooldown" | "pending";
+
+export type LinkedWallet = {
+  /** Display name, e.g. "0x1332…4a9f" or "vault.eth". */
+  display: string;
+  /**
+   * Full address to copy from the hover-to-copy control. When omitted, the copy
+   * affordance falls back to copying `display`. Lets the row show a short /
+   * truncated name while the clipboard still gets the complete address.
+   */
+  address?: string;
+  /** Short kind label, e.g. "Wallet" / "ENS" / "Safe". */
+  kind?: string;
+  /** Linking state. Defaults to "active" when omitted. */
+  status?: LinkedWalletStatus;
+  /**
+   * Short human reason shown for a non-active wallet, e.g. "Cooldown until Aug 3"
+   * or "Linking in progress". Kept plain; no crypto jargon.
+   */
+  cooldownUntil?: string;
+};
+
+export type ShellAccount = {
+  /** The passport account name, e.g. "Shady.eth". */
+  display: string;
+  /** The passport account's kind, e.g. "ENS". */
+  kind?: string;
+  /** The WaaP account's email (the account behind the passport). */
+  email?: string;
+  /** The WaaP account's address. */
+  address?: string;
+  /** Wallets / accounts already linked to this passport. */
+  linkedWallets?: LinkedWallet[];
+  /** Selectable identities for the switch-accounts zone. */
+  accounts?: ShellAccountOption[];
+};
+
+export type ShellSize = "full" | "pill" | "mini";
+
+export type PassportShellProps = {
+  /**
+   * Integrator's product icon (top-left slot). OPTIONAL and OFF by default:
+   * when omitted, the slot renders nothing (no placeholder box) and the header
+   * leads with the account selector. Pass a node to lead the header with the
+   * integrator's own brand mark.
+   */
+  appIcon?: React.ReactNode;
+  /**
+   * Optional integrator-supplied hover tooltip for the app-icon. Defaults to
+   * NONE: the app-icon is the integrator's brand, so we ship no explanatory
+   * copy of our own. When omitted, the icon renders with no tooltip. Only has
+   * an effect when `appIcon` is also supplied.
+   */
+  appIconTooltip?: React.ReactNode;
+  /** The passport identity + account menu. Omit to hide the selector. */
+  account?: ShellAccount;
+  /**
+   * Customization-API knob: show or hide the account selector in the header.
+   * Defaults to `true`. When `false`, the header omits the account selector
+   * entirely (leading with the app-icon if one is supplied, else nothing), even
+   * when `account` is provided. Useful for integrators who drive identity in
+   * their own chrome.
+   */
+  accountSelector?: boolean;
+  /** Index of the active account within `account.accounts`. */
+  activeAccountIndex?: number;
+  /** Called with the selected account index (switch accounts). */
+  onSelectAccount?: (index: number) => void;
+  /** Link an additional wallet to the passport (middle zone CTA). */
+  onLinkWallet?: () => void;
+  /** Unlink a linked wallet. Receives its index within `account.linkedWallets`. */
+  onUnlinkWallet?: (index: number) => void;
+  /** Sign out of the account (bottom zone). */
+  onSignOut?: () => void;
+  /** ⓘ help tooltip content. */
+  infoTooltip?: React.ReactNode;
+  /** Render the account menu open on mount (stories / controlled first-paint). */
+  defaultAccountMenuOpen?: boolean;
+  /**
+   * Paper-shader wash color as an "r, g, b" triplet, integrator-configurable.
+   * Defaults to the accent (emerald). Sets --rd-wash on the shell.
+   */
+  washRgb?: string;
+  /**
+   * Size variant. `full` (default) is the crafted card; `mini` is a condensed
+   * ~half-size card; `pill` is a compact single-row pill.
+   */
+  size?: ShellSize;
+  /** The window content (Score window, drill-down, …). */
+  children: React.ReactNode;
+  className?: string;
+};
+
+const DEFAULT_INFO_TIP =
+  "Your humanity score, proven with zero knowledge. Private by default. Nothing personal is revealed.";
+
+/** How many linked wallets show per page before the menu paginates (never scrolls). */
+const WALLETS_PER_PAGE = 3;
+
+const STATUS_LABEL: Record<LinkedWalletStatus, string> = {
+  active: "",
+  cooldown: "Cooldown",
+  pending: "Pending",
+};
+
+/**
+ * Hover-to-copy affordance for a wallet / address row. A small copy icon that
+ * stays hidden until the row is hovered or the button itself is focused (so it
+ * is keyboard-reachable). Clicking copies the full value to the clipboard and
+ * briefly swaps to a check + "Copied", reverting after ~1.5s. Presentational and
+ * self-contained; uses navigator.clipboard.writeText.
+ */
+const COPIED_MS = 1500;
+
+const CopyButton: React.FC<{ value: string; label: string }> = ({ value, label }) => {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const copy = useCallback(() => {
+    const done = () => {
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), COPIED_MS);
+    };
+    try {
+      const clip = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+      if (clip?.writeText) {
+        clip.writeText(value).then(done, done);
+      } else {
+        done();
+      }
+    } catch {
+      // Clipboard may be blocked (insecure context, permissions); still confirm.
+      done();
+    }
+  }, [value]);
+
+  return (
+    <button
+      type="button"
+      className={`${styles.copyBtn} ${copied ? styles.copyBtnDone : ""}`}
+      onClick={copy}
+      aria-label={copied ? "Copied" : label}
+      title={copied ? "Copied" : label}
+    >
+      <span className={styles.copyGlyph} aria-hidden="true">
+        {copied ? <CheckIcon size={13} strokeWidth={2.2} /> : <CopyIcon size={13} strokeWidth={1.7} />}
+      </span>
+      {copied ? <span className={styles.copyText}>Copied</span> : null}
+    </button>
+  );
+};
+
+const LinkedWalletRow: React.FC<{
+  wallet: LinkedWallet;
+  index: number;
+  onUnlink?: (index: number) => void;
+}> = ({ wallet, index, onUnlink }) => {
+  const status = wallet.status ?? "active";
+  const muted = status !== "active";
+  // Pending links are still settling, so unlink is not offered yet.
+  const canUnlink = Boolean(onUnlink) && status !== "pending";
+
+  return (
+    <div className={`${styles.walletRow} ${muted ? styles.walletRowMuted : ""}`}>
+      <span className={styles.walletIcon} aria-hidden="true">
+        <WalletIcon size={15} strokeWidth={1.8} />
+      </span>
+      <span className={styles.walletMeta}>
+        <span className={styles.walletName}>{wallet.display}</span>
+        {muted && wallet.cooldownUntil ? (
+          <span className={styles.walletReason}>{wallet.cooldownUntil}</span>
+        ) : null}
+      </span>
+      {muted ? (
+        <span className={styles.walletStatus} aria-label={STATUS_LABEL[status]}>
+          <ClockIcon size={11} strokeWidth={1.9} />
+          {STATUS_LABEL[status]}
+        </span>
+      ) : wallet.kind ? (
+        <span className={styles.walletKind}>{wallet.kind}</span>
+      ) : null}
+      <CopyButton value={wallet.address ?? wallet.display} label={`Copy ${wallet.display}`} />
+      {canUnlink ? (
+        <button
+          type="button"
+          className={styles.unlinkBtn}
+          onClick={() => onUnlink?.(index)}
+          aria-label={`Unlink ${wallet.display}`}
+          title={`Unlink ${wallet.display}`}
+        >
+          <UnlinkIcon size={14} strokeWidth={1.8} />
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+const AccountMenu: React.FC<{
+  account: ShellAccount;
+  activeIndex: number;
+  onSelect?: (index: number) => void;
+  onLinkWallet?: () => void;
+  onUnlinkWallet?: (index: number) => void;
+  onSignOut?: () => void;
+  defaultOpen?: boolean;
+}> = ({ account, activeIndex, onSelect, onLinkWallet, onUnlinkWallet, onSignOut, defaultOpen }) => {
+  const [open, setOpen] = useState(Boolean(defaultOpen));
+  const [walletPage, setWalletPage] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const switchOptions: ShellAccountOption[] = useMemo(
+    () =>
+      account.accounts && account.accounts.length
+        ? account.accounts
+        : [{ display: account.display, kind: account.kind }],
+    [account]
+  );
+  const linkedWallets = account.linkedWallets ?? [];
+  const pageCount = Math.max(1, Math.ceil(linkedWallets.length / WALLETS_PER_PAGE));
+  // Clamp in case the active page falls off the end (e.g. after an unlink).
+  const page = Math.min(walletPage, pageCount - 1);
+  const pageStart = page * WALLETS_PER_PAGE;
+  const pageWallets = linkedWallets.slice(pageStart, pageStart + WALLETS_PER_PAGE);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const select = (index: number) => {
+    onSelect?.(index);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={wrapRef} className={`${styles.acctWrap} ${open ? styles.acctOpen : ""}`}>
+      <button
+        type="button"
+        className={styles.acct}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.acctLabel}>Signed in</span>
+        <span className={styles.acctWho}>
+          <span className={styles.acctName}>{account.display}</span>
+          <span className={styles.acctOf}>&rsquo;s Passport</span>
+          <CaretDownIcon className={styles.acctCaret} size={13} />
+        </span>
+      </button>
+
+      <div className={styles.menu} role="menu" aria-label="Account">
+        {/* (a) top: the passport account = the WaaP account behind it */}
+        <div className={styles.zoneTop}>
+          <span className={styles.waapMark} aria-hidden="true">
+            <WaaPIcon size={20} />
+          </span>
+          <span className={styles.waapMeta}>
+            <span className={styles.waapName}>{account.display}</span>
+            {account.email ? <span className={styles.waapLine}>{account.email}</span> : null}
+            {account.address ? (
+              <span className={styles.waapAddrRow}>
+                <span className={styles.waapAddr}>{account.address}</span>
+                <CopyButton value={account.address} label="Copy address" />
+              </span>
+            ) : null}
+          </span>
+        </div>
+
+        {/* (b) middle: linked wallets (paginated, never scrolled) + link CTA */}
+        <div className={styles.zoneMid}>
+          <div className={styles.zoneHead}>Linked wallets</div>
+          {linkedWallets.length ? (
+            <>
+              {pageWallets.map((w, i) => (
+                <LinkedWalletRow
+                  key={`${w.display}-${pageStart + i}`}
+                  wallet={w}
+                  index={pageStart + i}
+                  onUnlink={onUnlinkWallet}
+                />
+              ))}
+              {pageCount > 1 ? (
+                <div className={styles.walletPager} role="group" aria-label="Linked wallet pages">
+                  <button
+                    type="button"
+                    className={styles.pagerArrow}
+                    onClick={() => setWalletPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    aria-label="Previous wallets"
+                  >
+                    <CaretDownIcon className={styles.pagerPrev} size={13} />
+                  </button>
+                  <span className={styles.pagerDots}>
+                    {Array.from({ length: pageCount }).map((_, i) => (
+                      <button
+                        type="button"
+                        key={i}
+                        className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+                        onClick={() => setWalletPage(i)}
+                        aria-label={`Wallet page ${i + 1}`}
+                        aria-current={i === page ? "true" : undefined}
+                      />
+                    ))}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.pagerArrow}
+                    onClick={() => setWalletPage(Math.min(pageCount - 1, page + 1))}
+                    disabled={page === pageCount - 1}
+                    aria-label="More wallets"
+                  >
+                    <CaretDownIcon className={styles.pagerNext} size={13} />
+                  </button>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className={styles.zoneEmpty}>No wallets linked yet.</div>
+          )}
+          <button type="button" className={styles.linkWalletBtn} onClick={onLinkWallet}>
+            <PlusIcon size={15} strokeWidth={2} />
+            Link additional wallet
+          </button>
+        </div>
+
+        {/* (c) bottom: switch accounts + sign out */}
+        <div className={styles.zoneBottom}>
+          {switchOptions.length > 1 ? (
+            <div className={styles.switchGroup} role="group" aria-label="Switch accounts">
+              <div className={styles.zoneHead}>
+                <SwitchIcon size={13} strokeWidth={1.8} />
+                Switch accounts
+              </div>
+              {switchOptions.map((opt, i) => (
+                <button
+                  type="button"
+                  key={`${opt.display}-${i}`}
+                  role="menuitem"
+                  className={`${styles.menuItem} ${i === activeIndex ? styles.menuItemOn : ""}`}
+                  onClick={() => select(i)}
+                >
+                  <span className={styles.menuAvatar} aria-hidden="true" />
+                  <span className={styles.menuName}>{opt.display}</span>
+                  {opt.kind ? <span className={styles.menuKind}>{opt.kind}</span> : null}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <button type="button" className={styles.signOut} onClick={onSignOut}>
+            <LogoutIcon size={15} strokeWidth={1.8} />
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * PassportShell - the persistent binding around every window. App-icon slot ·
+ * account menu · ⓘ help · the shared "Secured by human.tech" footer, all INSIDE
+ * the rounded bounds. Structure is space and tone, not hard lines. Presentational:
+ * props only, no data hooks, fully self-contained + theme-driven.
+ */
+export const PassportShell: React.FC<PassportShellProps> = ({
+  appIcon,
+  appIconTooltip,
+  account,
+  accountSelector = true,
+  activeAccountIndex = 0,
+  onSelectAccount,
+  onLinkWallet,
+  onUnlinkWallet,
+  onSignOut,
+  infoTooltip = DEFAULT_INFO_TIP,
+  defaultAccountMenuOpen,
+  washRgb,
+  size = "full",
+  children,
+  className = "",
+}) => {
+  const handleSelect = useCallback((i: number) => onSelectAccount?.(i), [onSelectAccount]);
+
+  // App-icon slot is OFF by default: only render it when the integrator supplies
+  // their own mark. When absent, the header simply leads with the account.
+  const appIconEl = appIcon ? (
+    <span className={styles.appIcon} tabIndex={appIconTooltip ? 0 : undefined} role="img" aria-label="App icon">
+      {appIcon}
+    </span>
+  ) : null;
+
+  // Whether the account selector actually shows: gated by the accountSelector
+  // knob AND by an account being supplied.
+  const showAccount = accountSelector && Boolean(account);
+
+  // The pill is a true single row: the score ring stands in for the app-icon,
+  // the account preview and the one action live in the window itself. It carries
+  // no header chrome (no app-icon, no account menu, no ⓘ), but it DOES keep the
+  // shared "Secured by human.tech" lockup in a compact form beneath the row so
+  // the mark is never dropped. (See PassportShell.stories / item 1.)
+  if (size === "pill") {
+    return (
+      <div
+        className={`${styles.shell} ${styles.pill} ${className}`}
+        style={washRgb ? ({ "--rd-wash": washRgb } as React.CSSProperties) : undefined}
+      >
+        <div className={styles.fx} aria-hidden="true" />
+        <div className={styles.content}>{children}</div>
+        <SecuredByFooter compact />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${styles.shell} ${styles[size]} ${className}`}
+      style={washRgb ? ({ "--rd-wash": washRgb } as React.CSSProperties) : undefined}
+    >
+      <div className={styles.fx} aria-hidden="true" />
+
+      <div className={styles.chrome}>
+        {/* The app-icon slot only appears when the integrator passes appIcon.
+            No default tooltip either: the icon is the integrator's brand, so we
+            wrap it only when they supply their own appIconTooltip copy. */}
+        {appIconEl ? (
+          appIconTooltip ? (
+            <Tooltip content={appIconTooltip} placement="bottom-start" className={glass.tip}>
+              {appIconEl}
+            </Tooltip>
+          ) : (
+            appIconEl
+          )
+        ) : null}
+
+        {showAccount && account ? (
+          <AccountMenu
+            account={account}
+            activeIndex={activeAccountIndex}
+            onSelect={handleSelect}
+            onLinkWallet={onLinkWallet}
+            onUnlinkWallet={onUnlinkWallet}
+            onSignOut={onSignOut}
+            defaultOpen={defaultAccountMenuOpen}
+          />
+        ) : (
+          <span className={styles.spacer} />
+        )}
+
+        <Tooltip content={infoTooltip} placement="bottom-end" className={glass.tip}>
+          <span className={styles.info} tabIndex={0} role="button" aria-label="About your score">
+            <InfoIcon className={styles.gl} size={13} />
+          </span>
+        </Tooltip>
+      </div>
+
+      <div className={styles.content}>{children}</div>
+
+      <SecuredByFooter />
+    </div>
+  );
+};

--- a/src/redesign/ScoreDrilldown.module.css
+++ b/src/redesign/ScoreDrilldown.module.css
@@ -1,0 +1,171 @@
+/*
+ * ScoreDrilldown - the single ring resolves into disconnected arcs whose LENGTH
+ * encodes each stamp's contribution (uniform stroke-width), points ON each arc,
+ * names close to their arc, palette derived from the accent hue only. No legend,
+ * no "sums to total" caption (SOP §4). Everything scales inside one viewBox so
+ * nothing clips.
+ */
+
+.drilldown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-c6dbf459);
+  width: 100%;
+}
+
+.back {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  align-self: flex-start;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 4px;
+  margin-bottom: var(--space-1-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  color: rgba(var(--on-surface), 0.72);
+  font-family: var(--font-family-body-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+}
+/* Invisible ≥40px hit target (a11y §8): ~18px tall + 2×11px = 40px. Visual size unchanged. */
+.back::before {
+  content: "";
+  position: absolute;
+  inset: -11px;
+}
+.back:hover {
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.06);
+}
+.back:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 1px;
+}
+
+.arcSvg {
+  width: 100%;
+  height: auto;
+  display: block;
+  margin-top: var(--space-1-c6dbf459);
+  overflow: visible;
+}
+
+/* Each segment is tappable: fires onSelectStamp (stamp-detail is a later slice).
+ * No hard outline; the whole group lifts slightly on hover / focus. */
+.segment {
+  cursor: pointer;
+  transition: opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+  outline: none;
+}
+.segment:hover {
+  opacity: 0.82;
+}
+.segment:focus-visible .arc {
+  stroke-width: 19;
+}
+.segment:focus-visible .arcPt {
+  font-size: 15px;
+}
+
+.track {
+  fill: none;
+  stroke: rgba(var(--on-surface), 0.1);
+  stroke-width: 16;
+}
+
+.arc {
+  transition: stroke-dashoffset var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459);
+}
+
+/* the point rides ON its band - white with a dark halo so it reads over any
+ * mid-tone tint, in both themes (paint-order draws the halo behind the fill) */
+.arcPt {
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-size: 13px;
+  fill: #fff;
+  paint-order: stroke;
+  stroke: rgba(0, 0, 0, 0.55);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+  font-variant-numeric: tabular-nums;
+}
+
+/* the name sits just outside its band - theme text color for guaranteed
+ * contrast (association is by proximity, not by a color legend) */
+.arcLabel {
+  font-family: var(--font-family-body-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  fill: rgb(var(--on-surface));
+}
+
+.total {
+  fill: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-size: 38px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* "See all stamps" CTA: tonal (no hard line), full width, inside the shell. */
+.seeAll {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 42px;
+  margin-top: var(--space-3-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  transition: background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.seeAll:hover {
+  background: rgba(var(--on-surface), 0.12);
+}
+.seeAll:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.resolveIn {
+  animation: resolveIn 0.6s var(--ease-standard-c6dbf459) both;
+  transform-origin: 180px 120px;
+}
+@keyframes resolveIn {
+  from {
+    opacity: 0;
+    transform: scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arc,
+  .resolveIn {
+    transition: none;
+    animation: none;
+  }
+}

--- a/src/redesign/ScoreDrilldown.stories.tsx
+++ b/src/redesign/ScoreDrilldown.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ScoreDrilldown } from "./ScoreDrilldown";
+import { PassportShell } from "./PassportShell";
+import { ScoreHome } from "./ScoreHome";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_STAMPS } from "./storyFrame";
+
+/**
+ * ScoreDrilldown - arc LENGTH proportional to contribution, uniform stroke,
+ * points ON each arc, names close by, palette derived from the accent hue only.
+ * No legend, no header, no "sums to total" caption. Both themes.
+ */
+const meta: Meta<typeof ScoreDrilldown> = {
+  title: "Redesign/Score Drilldown",
+  component: ScoreDrilldown,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof ScoreDrilldown>;
+
+export const Breakdown: Story = {
+  name: "Drilldown / Breakdown",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreDrilldown
+          stamps={SAMPLE_STAMPS}
+          total={24}
+          onBack={() => undefined}
+          onSelectStamp={() => undefined}
+          onSeeAllStamps={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The single ring resolved into disconnected component arcs, with no header so the breakdown fills the window. Arc length grows with points; stroke-width is uniform; each arc carries its own points with the stamp name just outside. Tapping a segment fires onSelectStamp. A 'See all stamps' CTA sits below.",
+      },
+    },
+  },
+};
+
+export const ScoreToDrilldown: Story = {
+  name: "Drilldown / Tap the score to open",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreHome
+          state="verified"
+          score={24}
+          threshold={20}
+          stamps={SAMPLE_STAMPS}
+          onContinue={() => undefined}
+          onSelectStamp={() => undefined}
+          onSeeAllStamps={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tap the score (ring or the inline verified check) to flip into the drill-down; 'Back to score' returns. Verified state shown; the same tap works below the threshold.",
+      },
+    },
+  },
+};

--- a/src/redesign/ScoreDrilldown.tsx
+++ b/src/redesign/ScoreDrilldown.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo, useRef } from "react";
+import styles from "./ScoreDrilldown.module.css";
+import { ArrowLeftIcon, SparkIcon } from "./icons";
+import { deriveTints } from "./deriveTints";
+import { useAccentRgb, useCountUp, useReducedMotion } from "./hooks";
+
+export type StampContribution = {
+  /** Stable id passed back through onSelectStamp. Falls back to `label`. */
+  id?: string;
+  /** Short stamp label, e.g. "Government ID". */
+  label: string;
+  /** Points this stamp contributes to the total. */
+  points: number;
+};
+
+export type ScoreDrilldownProps = {
+  stamps: StampContribution[];
+  /** Total shown in the ring center. Defaults to the sum of contributions. */
+  total?: number;
+  /** Override the accent triplet ("r, g, b"). Defaults to the resolved --accent. */
+  accentRgb?: string;
+  /** Return to the Score window. */
+  onBack?: () => void;
+  /** Fired when a breakdown segment is tapped (stamp-detail is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /** Fired by the "See all stamps" CTA. */
+  onSeeAllStamps?: () => void;
+};
+
+// Ring geometry lives inside a generous viewBox that scales down to the widget
+// width, so labels are always INSIDE the frame and nothing clips. The breakdown
+// is the whole window now (no header), so the ring is larger.
+const CX = 180;
+const CY = 118;
+const R = 78;
+const SW = 16; // uniform stroke-width on EVERY arc: contribution shows in LENGTH only
+const GAP = 8;
+const C = 2 * Math.PI * R;
+
+type Segment = {
+  id: string;
+  label: string;
+  points: number;
+  color: string;
+  dash: string;
+  offset: number;
+  ptX: number;
+  ptY: number;
+  labelX: number;
+  labelY: number;
+  labelAnchor: "start" | "end" | "middle";
+};
+
+export const ScoreDrilldown: React.FC<ScoreDrilldownProps> = ({
+  stamps,
+  total,
+  accentRgb,
+  onBack,
+  onSelectStamp,
+  onSeeAllStamps,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const accent = useAccentRgb(rootRef, accentRgb);
+
+  const sum = total ?? stamps.reduce((a, s) => a + s.points, 0);
+  const counted = useCountUp(sum, 900, reduced);
+
+  const segments = useMemo<Segment[]>(() => {
+    const denom = stamps.reduce((a, s) => a + s.points, 0) || 1;
+    const ranked = stamps.slice().sort((a, b) => b.points - a.points);
+    const tints = deriveTints(accent, stamps.length);
+    let pos = 0;
+    return stamps.map((s) => {
+      const rank = ranked.indexOf(s);
+      const frac = s.points / denom;
+      const arcLen = frac * C;
+      const draw = Math.max(6, arcLen - GAP);
+      const midAngle = ((pos + arcLen / 2) / C) * 2 * Math.PI - Math.PI / 2;
+      const ux = Math.cos(midAngle);
+      const uy = Math.sin(midAngle);
+      const lr = R + SW / 2 + 12;
+      const seg: Segment = {
+        id: s.id ?? s.label,
+        label: s.label,
+        points: s.points,
+        color: tints[Math.max(0, rank)],
+        dash: `${draw.toFixed(2)} ${(C - draw).toFixed(2)}`,
+        offset: -(pos + GAP / 2),
+        ptX: CX + ux * R,
+        ptY: CY + uy * R,
+        labelX: CX + ux * lr,
+        labelY: CY + uy * lr,
+        labelAnchor: ux >= 0.15 ? "start" : ux <= -0.15 ? "end" : "middle",
+      };
+      pos += arcLen;
+      return seg;
+    });
+  }, [stamps, accent]);
+
+  return (
+    <div ref={rootRef} className={styles.drilldown}>
+      <div className={styles.head}>
+        {onBack ? (
+          <button type="button" className={styles.back} onClick={onBack}>
+            <ArrowLeftIcon size={13} />
+            Back to score
+          </button>
+        ) : (
+          <span />
+        )}
+      </div>
+
+      <svg className={styles.arcSvg} viewBox="0 0 360 236" role="img" aria-label={`Score breakdown, total ${sum}`}>
+        {/* faint track the arcs sit on */}
+        <circle className={styles.track} cx={CX} cy={CY} r={R} />
+
+        <g className={reduced ? "" : styles.resolveIn}>
+          {segments.map((seg, i) => (
+            <g
+              key={`${seg.id}-${i}`}
+              className={onSelectStamp ? styles.segment : undefined}
+              role={onSelectStamp ? "button" : undefined}
+              tabIndex={onSelectStamp ? 0 : undefined}
+              aria-label={onSelectStamp ? `${seg.label}, ${seg.points} points. Open stamp.` : undefined}
+              onClick={onSelectStamp ? () => onSelectStamp(seg.id) : undefined}
+              onKeyDown={
+                onSelectStamp
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSelectStamp(seg.id);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <circle
+                className={styles.arc}
+                cx={CX}
+                cy={CY}
+                r={R}
+                fill="none"
+                stroke={seg.color}
+                strokeWidth={SW}
+                strokeLinecap="round"
+                transform={`rotate(-90 ${CX} ${CY})`}
+                strokeDasharray={seg.dash}
+                strokeDashoffset={seg.offset}
+              />
+              <text
+                className={styles.arcPt}
+                x={seg.ptX.toFixed(1)}
+                y={seg.ptY.toFixed(1)}
+                textAnchor="middle"
+                dominantBaseline="central"
+              >
+                {seg.points}
+              </text>
+              <text
+                className={styles.arcLabel}
+                x={seg.labelX.toFixed(1)}
+                y={seg.labelY.toFixed(1)}
+                textAnchor={seg.labelAnchor}
+                dominantBaseline="middle"
+              >
+                {seg.label}
+              </text>
+            </g>
+          ))}
+        </g>
+
+        <text className={styles.total} x={CX} y={CY} textAnchor="middle" dominantBaseline="central">
+          {Math.round(counted)}
+        </text>
+      </svg>
+
+      <button type="button" className={styles.seeAll} onClick={onSeeAllStamps}>
+        <SparkIcon size={15} strokeWidth={1.9} />
+        See all stamps
+      </button>
+    </div>
+  );
+};

--- a/src/redesign/ScoreHome.tsx
+++ b/src/redesign/ScoreHome.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import { ScoreWindow, ScoreWindowProps } from "./ScoreWindow";
+import { ScoreDrilldown, StampContribution } from "./ScoreDrilldown";
+
+export type ScoreHomeProps = Omit<ScoreWindowProps, "onDrilldown"> & {
+  /** Contribution breakdown shown when the score is tapped. */
+  stamps: StampContribution[];
+  /** Start on the drill-down (stories / deep-link). */
+  defaultView?: "score" | "drilldown";
+  /** Fired when a breakdown segment is tapped (stamp-detail is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /** Fired by the "See all stamps" CTA in the drill-down. */
+  onSeeAllStamps?: () => void;
+};
+
+/**
+ * ScoreHome - thin presentational connector that toggles between the Score
+ * window and its drill-down when the score is tapped. Holds only local view
+ * state (no data hooks), so it stays fully storybookable.
+ */
+export const ScoreHome: React.FC<ScoreHomeProps> = ({
+  stamps,
+  defaultView = "score",
+  onSelectStamp,
+  onSeeAllStamps,
+  ...scoreProps
+}) => {
+  const [view, setView] = useState<"score" | "drilldown">(defaultView);
+
+  if (view === "drilldown") {
+    return (
+      <ScoreDrilldown
+        stamps={stamps}
+        total={scoreProps.score}
+        onBack={() => setView("score")}
+        onSelectStamp={onSelectStamp}
+        onSeeAllStamps={onSeeAllStamps}
+      />
+    );
+  }
+
+  return <ScoreWindow {...scoreProps} onDrilldown={() => setView("drilldown")} />;
+};

--- a/src/redesign/ScoreWindow.module.css
+++ b/src/redesign/ScoreWindow.module.css
@@ -1,0 +1,468 @@
+/*
+ * ScoreWindow - the home / spine. True SVG ring (emerald at/above threshold,
+ * amber below), score is the tap target, cryptex-spirit loader, inline verified
+ * reward. Tokens only (§1); legible in both themes (§2/§8);
+ * all motion degrades under reduced-motion (§4).
+ *
+ * Local display sizes: the big score digit is intentionally larger than the
+ * type scale's ceiling (xl = 20). Declared here as scoped tokens rather than
+ * bare px so they remain single-sourced and re-themable within the redesign.
+ */
+
+.window {
+  --rd-score-digit: 40px;
+  --rd-loader-mark: rgba(var(--accent), 0.9);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  text-align: center;
+  /* Fill the fixed-height content region so the action area can bottom-anchor
+   * (§ structure): the primary CTA lands at the same coordinates in every
+   * state. The score / message area flexes; the buttons do not move. */
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- ring ---- */
+.ringWrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  margin: var(--space-2-c6dbf459) 0 var(--space-1-c6dbf459);
+}
+
+.ringSvg {
+  width: 150px;
+  height: 150px;
+  display: block;
+}
+
+.ringTrack {
+  fill: none;
+  stroke: rgba(var(--on-surface), 0.13);
+  stroke-width: 9;
+}
+
+.ringProgress {
+  fill: none;
+  stroke-width: 9;
+  stroke-linecap: round;
+  transition:
+    stroke-dashoffset var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459),
+    stroke var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Emerald only at or above the threshold. */
+.ringPass {
+  stroke: rgb(var(--accent));
+}
+/* Warm amber below the threshold: "almost there, not yet passing". */
+.ringWarn {
+  stroke: rgb(var(--warn));
+}
+
+/* The whole score (ring + number) is the hover / tap target. Bare button:
+ * no background, no border (no hard lines), just a pointer + focus ring. */
+.ringButton {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  display: block;
+  cursor: pointer;
+  color: inherit;
+  border-radius: var(--radius-pill-c6dbf459);
+}
+.ringButton:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 4px;
+}
+
+.ringNum {
+  position: absolute;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  color: rgb(var(--on-surface));
+  font-variant-numeric: tabular-nums;
+}
+
+.scoreWrap {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.count {
+  font-size: var(--rd-score-digit);
+  font-weight: var(--weight-bold-c6dbf459);
+  letter-spacing: -0.035em;
+  line-height: var(--line-tight-c6dbf459);
+  font-variant-numeric: tabular-nums;
+}
+
+.outOf {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.7);
+  margin-left: 3px;
+}
+
+/* ---- verified: inline "check + You're verified", animated in together ---- */
+.verifiedLine {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  margin: var(--space-3-c6dbf459) 0 0;
+  animation: verifiedIn 0.5s var(--ease-standard-c6dbf459) 0.35s both;
+}
+.verifiedLineStatic {
+  animation: none;
+}
+@keyframes verifiedIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The green seal / check, now inline with the headline and tappable. */
+.inlineSeal {
+  appearance: none;
+  border: 0;
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: rgb(var(--on-accent));
+  background: radial-gradient(circle at 35% 28%, rgba(255, 255, 255, 0.9), rgb(var(--accent)) 80%);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition: filter var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Invisible >=40px hit target (a11y §8): 24px + 2×8px = 40px. */
+.inlineSeal::before {
+  content: "";
+  position: absolute;
+  inset: -8px;
+}
+.inlineSeal:hover {
+  filter: brightness(1.06);
+}
+.inlineSeal:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.verifiedText {
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-lg-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+
+.ringGlow {
+  position: absolute;
+  width: 150px;
+  height: 150px;
+  border-radius: var(--radius-pill-c6dbf459);
+  pointer-events: none;
+  opacity: 0;
+}
+.celebrate .ringGlow {
+  animation: glowPulse 1.6s ease-out 0.1s both;
+}
+@keyframes glowPulse {
+  0% {
+    opacity: 0;
+    box-shadow: 0 0 0 0 rgba(var(--accent), 0.5);
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    box-shadow: 0 0 0 24px rgba(var(--accent), 0);
+  }
+}
+
+/* Interim loading spinner (indeterminate emerald arc). To be replaced by the
+ * shared Cryptex loader from @holonym-foundation/ui once it is an installable
+ * dependency. Its source is NOT vendored into this public repo. */
+.spin {
+  animation: rdSpin 1s linear infinite;
+  transform-origin: center;
+}
+@keyframes rdSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
+  }
+}
+
+/* ---- text ---- */
+.headline {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-lg-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  margin: var(--space-2-c6dbf459) 0 0;
+  text-wrap: balance;
+}
+
+.sub {
+  color: rgba(var(--on-surface), 0.72);
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  margin: var(--space-1-c6dbf459) 0 0;
+}
+.sub b {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+
+/* ---- to-go progress framing (below threshold) ---- */
+.toGo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+  margin: var(--space-3-c6dbf459) 0 0;
+  padding: var(--space-2-c6dbf459) var(--space-3-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  background: rgba(var(--on-surface), 0.05);
+  box-sizing: border-box;
+}
+.toGoBar {
+  flex: 1;
+  height: 5px;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.13);
+  overflow: hidden;
+}
+.toGoBar i {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-pill-c6dbf459);
+  /* Below the threshold, so the progress fill is amber to match the ring. */
+  background: rgb(var(--warn));
+  transition: width var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.toGoLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  white-space: nowrap;
+}
+
+/* ---- error ---- */
+.errorBadge {
+  width: 56px;
+  height: 56px;
+  margin: var(--space-4-c6dbf459) 0 var(--space-3-c6dbf459);
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--danger));
+  background: rgba(var(--danger), 0.12);
+}
+
+/* ---- CTAs ---- */
+/* Below-threshold action area holds the two configurable CTAs, stacked.
+ * margin-top:auto pins the whole action area to the bottom of the window so the
+ * primary CTA sits at a fixed y across states. */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+  margin-top: auto;
+}
+
+/* ONE shared button metric. Every action button - primary, secondary, the
+ * verified Continue, the error retry - is full width with identical height and
+ * padding. Only the color differs (emerald primary vs tonal secondary). A
+ * standalone .cta (verified / error) bottom-anchors via margin-top:auto. */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  margin-top: auto;
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Buttons inside the stacked action area own their spacing via the flex gap. */
+.actions .cta {
+  margin-top: 0;
+}
+/* The label never wraps, so both CTAs keep the identical single-row box. */
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* Secondary CTA (link wallet): tonal, no hard line. Reads as a quieter step
+ * than the emerald primary, legible in both themes via on-surface tint. */
+.ctaSecondary {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  box-shadow: none;
+}
+.ctaSecondary:hover {
+  filter: none;
+  background: rgba(var(--on-surface), 0.12);
+}
+
+.ctaIcon {
+  display: inline-flex;
+}
+
+/* ---- size variants (§ structure): mini = condensed ~half card, pill = one
+ * compact horizontal row. full is the default layout above. ---- */
+
+/* mini: smaller ring + digit, tighter spacing, primary action only. */
+.miniWin {
+  --rd-score-digit: 26px;
+}
+.miniWin .ringWrap {
+  margin: 0 0 var(--space-1-c6dbf459);
+}
+.miniWin .ringSvg {
+  width: 100px;
+  height: 100px;
+}
+.miniWin .headline {
+  font-size: var(--font-size-md-c6dbf459);
+  margin-top: var(--space-1-c6dbf459);
+}
+.miniWin .verifiedText {
+  font-size: var(--font-size-md-c6dbf459);
+}
+.miniWin .verifiedLine {
+  margin-top: var(--space-2-c6dbf459);
+}
+
+/* pill: a single horizontal row - compact score + label + one action. */
+.pillWin {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  text-align: left;
+  gap: var(--space-2-c6dbf459);
+  --rd-score-digit: 15px;
+}
+.pillWin .ringWrap {
+  margin: 0;
+  flex: none;
+}
+.pillWin .ringSvg {
+  width: 44px;
+  height: 44px;
+}
+.pillWin .ringTrack,
+.pillWin .ringProgress {
+  stroke-width: 11;
+}
+.pillWin .outOf {
+  display: none;
+}
+.pillText {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pillWin .headline {
+  margin: 0;
+}
+
+/* Compact error mark for the pill error row: same danger tint as the full badge,
+ * sized to sit inside the single pill row where the ring would otherwise be. */
+.pillErrorBadge {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--danger));
+  background: rgba(var(--danger), 0.12);
+}
+
+/* Inline (auto-width) action used by the pill row: same look, compact box. */
+.ctaInline {
+  width: auto;
+  flex: none;
+  height: 34px;
+  margin-top: 0;
+  padding: 0 var(--space-3-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ringProgress,
+  .toGoBar i,
+  .cta {
+    transition: none;
+  }
+  .ringGlow,
+  .verifiedLine {
+    animation: none;
+  }
+}

--- a/src/redesign/ScoreWindow.stories.tsx
+++ b/src/redesign/ScoreWindow.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ScoreWindow } from "./ScoreWindow";
+import { PassportShell } from "./PassportShell";
+import { ThemePair, SAMPLE_ACCOUNT } from "./storyFrame";
+
+/**
+ * ScoreWindow - the home / spine, in every state, composed inside the shell so
+ * the overlay rules (nothing outside the shell, ring not clipped, tooltips never
+ * clipped) are visible. Both themes, no network.
+ */
+const meta: Meta<typeof ScoreWindow> = {
+  title: "Redesign/Score Window",
+  component: ScoreWindow,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof ScoreWindow>;
+
+const inShell = (node: React.ReactNode) => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT}>{node}</PassportShell>
+  </ThemePair>
+);
+
+export const Loading: Story = {
+  name: "Score / Loading",
+  render: () => inShell(<ScoreWindow state="loading" />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interim loading state: a simple indeterminate emerald arc. This will be replaced by the shared Cryptex loader from @holonym-foundation/ui once that package is installable as a dependency (its source is not copied into this public repo).",
+      },
+    },
+  },
+};
+
+export const BelowThreshold: Story = {
+  name: "Score / Below threshold",
+  render: () =>
+    inShell(
+      <ScoreWindow
+        state="below"
+        score={17}
+        threshold={20}
+        addVerificationsCta={{ onClick: () => undefined }}
+        linkIdentityCta={{ onClick: () => undefined }}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Below the threshold the ring is amber, not emerald. Hover the score for its state and the tap-to-compute hint. Two configurable CTAs share one box metric (both full width, identical height and padding): the emerald 'Add verifications' primary and the tonal 'Link an identity' secondary, the latter with a chain-link icon. Both sit in the bottom-pinned action area so the primary CTA lands at the same y as the verified Continue.",
+      },
+    },
+  },
+};
+
+export const Verified: Story = {
+  name: "Score / Verified (reward)",
+  render: () => inShell(<ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Crossing the threshold is a reward: the ring completes in emerald and a glow pulses. There is no badge inside the ring. The green check sits inline with 'You're verified' and animates in with the text. Hover the check for 'Score 24. Above the threshold.' A single 'Continue' hand-off CTA.",
+      },
+    },
+  },
+};
+
+export const ErrorState: Story = {
+  name: "Score / Error",
+  render: () => inShell(<ScoreWindow state="error" errorKind="network" onRetry={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story: "Humanized error copy mapped from the failure kind (network here), never a raw error.message, plus a retry CTA.",
+      },
+    },
+  },
+};

--- a/src/redesign/ScoreWindow.tsx
+++ b/src/redesign/ScoreWindow.tsx
@@ -1,0 +1,430 @@
+import React from "react";
+import styles from "./ScoreWindow.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import { CheckIcon, LinkIcon, PlusIcon, RetryIcon } from "./icons";
+import { useCountUp, useReducedMotion } from "./hooks";
+import { humanizeError, ErrorKind } from "./humanizeError";
+import type { ShellSize } from "./PassportShell";
+
+export type ScoreWindowState = "loading" | "below" | "verified" | "error";
+
+/** A dev-configurable call to action. Omit `onClick` to leave it inert; set
+ *  `hidden` to drop it from the action area entirely. */
+export type ShellCta = {
+  label?: string;
+  onClick?: () => void;
+  hidden?: boolean;
+};
+
+export type ScoreWindowProps = {
+  state: ScoreWindowState;
+  /** Current humanity score (below / verified states). */
+  score?: number;
+  /** Passing threshold. The single source of truth for it comes from score data. */
+  threshold?: number;
+  /** Tap the score (ring / number) to open the drill-down. */
+  onDrilldown?: () => void;
+
+  /** Below-threshold action area, CTA 1: add stamps / verifications. */
+  addVerificationsCta?: ShellCta;
+  /** Below-threshold action area, CTA 2: link an identity (a wallet / account)
+   *  to import reputation. Present in the onboarding / below-threshold flow,
+   *  dev-invokable. */
+  linkIdentityCta?: ShellCta;
+
+  /** Verified hand-off CTA (Continue back to the host app). */
+  onContinue?: () => void;
+  /** Override the verified hand-off CTA label. */
+  continueLabel?: string;
+
+  /** Retry handler for the error state. */
+  onRetry?: () => void;
+  /** Error kind, or the thrown value, mapped to friendly copy (never a raw
+   *  error.message). */
+  errorKind?: ErrorKind;
+  error?: unknown;
+  /** Optional explicit override of the humanized error message. */
+  errorMessage?: string;
+
+  /** Override the default per-state headline. */
+  headline?: string;
+  /** Override the default per-state subtext. */
+  subtext?: string;
+
+  /**
+   * Pill-only: the account name / short address preview shown between the score
+   * ring and the action on the single pill row (e.g. "Shady.eth" or
+   * "0x1332…4a9f"). Ignored by the full / mini layouts, which carry the account
+   * in the shell chrome instead.
+   */
+  accountPreview?: string;
+
+  /**
+   * Size variant, mirrors the shell's. `full` (default) is the crafted card;
+   * `mini` is a condensed ~half-size card; `pill` is a compact single-row pill
+   * (mark + score + one action). Pass the SAME value you pass to PassportShell.
+   */
+  size?: ShellSize;
+
+  /**
+   * Customization-API knob: render the action button or not. Defaults to `true`.
+   * When `false`, the window shows a status-only readout with no action button
+   * (score + preview / message only). Most useful on the `pill` size to ship a
+   * read-only status pill, but honored on every size and state.
+   */
+  showAction?: boolean;
+};
+
+const RING_RADIUS = 54;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+const COUNT_MS = 1000;
+
+/** Loader diameter (px) per shell size variant. */
+const LOADER_PX: Record<ShellSize, number> = { full: 116, mini: 76, pill: 40 };
+
+/** True circular progress ring. Emerald at or above the threshold, amber below. */
+const ScoreRing: React.FC<{
+  fill: number; // 0..1
+  passing: boolean;
+  celebrate?: boolean;
+  reduced: boolean;
+  children: React.ReactNode;
+}> = ({ fill, passing, celebrate, reduced, children }) => {
+  const target = Math.max(0, Math.min(1, fill));
+  const [offset, setOffset] = React.useState(reduced ? RING_CIRCUMFERENCE * (1 - target) : RING_CIRCUMFERENCE);
+
+  React.useEffect(() => {
+    if (reduced) {
+      setOffset(RING_CIRCUMFERENCE * (1 - target));
+      return;
+    }
+    setOffset(RING_CIRCUMFERENCE);
+    const raf = requestAnimationFrame(() => setOffset(RING_CIRCUMFERENCE * (1 - target)));
+    return () => cancelAnimationFrame(raf);
+  }, [target, reduced]);
+
+  return (
+    <div className={`${styles.ringWrap} ${celebrate ? styles.celebrate : ""}`}>
+      {celebrate ? <span className={styles.ringGlow} aria-hidden="true" /> : null}
+      <svg className={styles.ringSvg} viewBox="0 0 150 150" aria-hidden="true">
+        <circle className={styles.ringTrack} cx="75" cy="75" r={RING_RADIUS} />
+        <circle
+          className={`${styles.ringProgress} ${passing ? styles.ringPass : styles.ringWarn}`}
+          cx="75"
+          cy="75"
+          r={RING_RADIUS}
+          transform="rotate(-90 75 75)"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={offset}
+        />
+      </svg>
+      <div className={styles.ringNum}>{children}</div>
+    </div>
+  );
+};
+
+/**
+ * Interim loader for the score-loading state: a simple indeterminate emerald arc.
+ * TODO: swap to the shared Cryptex loader from `@holonym-foundation/ui` once that
+ * package is installable by this build. Do NOT vendor its source into this public
+ * repo. Consume it as a dependency (see design-sop §7 reuse-shared-components).
+ */
+const ScoreLoader: React.FC<{ size: ShellSize }> = ({ size }) => {
+  const reduced = useReducedMotion();
+  const px = LOADER_PX[size];
+  return (
+    <div className={styles.ringWrap} role="status" aria-label="Checking your score">
+      <svg width={px} height={px} viewBox="0 0 48 48" aria-hidden className={reduced ? undefined : styles.spin}>
+        <circle cx="24" cy="24" r="20" fill="none" stroke="rgba(var(--muted), 0.25)" strokeWidth="4" />
+        <path d="M24 4 a20 20 0 0 1 20 20" fill="none" stroke="rgb(var(--accent))" strokeWidth="4" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+};
+
+/** One action button. Emerald primary or tonal secondary. All action buttons
+ *  share ONE box metric (full width, same height + padding); only color differs. */
+const ActionButton: React.FC<{
+  variant: "primary" | "secondary";
+  onClick?: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ variant, onClick, icon, children }) => (
+  <button
+    type="button"
+    className={`${styles.cta} ${variant === "secondary" ? styles.ctaSecondary : ""}`}
+    onClick={onClick}
+  >
+    <span className={styles.ctaIcon}>{icon}</span>
+    <span className={styles.ctaLabel}>{children}</span>
+  </button>
+);
+
+export const ScoreWindow: React.FC<ScoreWindowProps> = ({
+  state,
+  score = 0,
+  threshold = 20,
+  onDrilldown,
+  addVerificationsCta,
+  linkIdentityCta,
+  onContinue,
+  continueLabel,
+  onRetry,
+  errorKind,
+  error,
+  errorMessage,
+  headline,
+  subtext,
+  accountPreview,
+  size = "full",
+  showAction = true,
+}) => {
+  const reduced = useReducedMotion();
+  const toGo = Math.max(0, Math.ceil(threshold - score));
+  const fill = threshold > 0 ? score / threshold : 0;
+  const counted = useCountUp(score, COUNT_MS, reduced || state === "loading" || state === "error");
+  const shownScore = Math.round(counted);
+  const compact = size !== "full";
+  const verified = state === "verified";
+  const roundedScore = Math.round(score);
+  const winClass = `${styles.window} ${size === "mini" ? styles.miniWin : ""} ${size === "pill" ? styles.pillWin : ""}`;
+
+  const addCta = addVerificationsCta ?? {};
+  const idCta = linkIdentityCta ?? {};
+
+  // The score (ring + number) is itself the hover / tap target: the tooltip
+  // tells the user the state and that they can tap to see how it is computed.
+  // (Only meaningful for the below / verified states.)
+  const ringTip = verified ? (
+    <>
+      Verified and above the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+    </>
+  ) : (
+    <>
+      {toGo} more to reach the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+    </>
+  );
+  const ringLabel = verified
+    ? "Verified and above the threshold. Tap to see how your score is computed."
+    : `${toGo} more to reach the threshold. Tap to see how your score is computed.`;
+
+  const ringButton = (
+    <Tooltip content={ringTip} placement="top" className={glass.tip}>
+      <button type="button" className={styles.ringButton} onClick={onDrilldown} aria-label={ringLabel}>
+        <ScoreRing fill={verified ? 1 : fill} passing={verified} celebrate={verified && !compact} reduced={reduced}>
+          <span className={styles.scoreWrap}>
+            <span className={styles.count}>{shownScore}</span>
+            {verified ? null : <small className={styles.outOf}>/{threshold}</small>}
+          </span>
+        </ScoreRing>
+      </button>
+    </Tooltip>
+  );
+
+  // ---- pill: one true single short row in EVERY state. loading = small loader
+  // + short label; below = small ring + "N to go" + a compact action; verified =
+  // ring + account preview + Continue; error = compact message + retry. With
+  // showAction={false} the action drops and the pill is a status-only readout
+  // (score / message + preview). No "Verified" word, no footer here (the shell
+  // owns the compact footer); the only tooltip is the score-hover on the ring. ----
+  if (size === "pill") {
+    if (state === "loading") {
+      return (
+        <div className={winClass}>
+          <ScoreLoader size="pill" />
+          <span className={styles.pillText}>{headline ?? "Checking your score"}</span>
+        </div>
+      );
+    }
+
+    if (state === "error") {
+      const human = humanizeError(errorKind ?? error);
+      // Keep the pill to one short row: the compact title, not the full sentence.
+      const message = errorMessage ?? subtext ?? human.title;
+      return (
+        <div className={winClass}>
+          <span className={styles.pillErrorBadge} aria-hidden="true">
+            <RetryIcon size={16} />
+          </span>
+          <span className={styles.pillText} role="alert">
+            {message}
+          </span>
+          {showAction && human.retryable && onRetry ? (
+            <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onRetry}>
+              <span className={styles.ctaIcon}>
+                <RetryIcon size={14} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>Retry</span>
+            </button>
+          ) : null}
+        </div>
+      );
+    }
+
+    // below / verified: ring + label + one action. Below shows "N to go"; verified
+    // shows the account preview.
+    const pillLabel = verified ? accountPreview : `${toGo} to go`;
+    return (
+      <div className={winClass}>
+        <p className={styles.srOnly} aria-live="polite">
+          Score {roundedScore} of {threshold}. {verified ? "Above the threshold." : `${toGo} to go.`}
+        </p>
+        {ringButton}
+        {pillLabel ? <span className={styles.pillText}>{pillLabel}</span> : <span className={styles.pillText} />}
+        {!showAction ? null : verified ? (
+          <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onContinue}>
+            <span className={styles.ctaLabel}>{continueLabel ?? "Continue"}</span>
+          </button>
+        ) : addCta.hidden ? null : (
+          <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={addCta.onClick}>
+            <span className={styles.ctaIcon}>
+              <PlusIcon size={14} strokeWidth={2} />
+            </span>
+            <span className={styles.ctaLabel}>{addCta.label ?? "Verify"}</span>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (state === "loading") {
+    return (
+      <div className={winClass}>
+        <ScoreLoader size={size} />
+        <p className={styles.headline}>{headline ?? "Checking your score"}</p>
+        <p className={styles.sub}>{subtext ?? "This only takes a moment."}</p>
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    const human = humanizeError(errorKind ?? error);
+    const title = headline ?? human.title;
+    const message = errorMessage ?? subtext ?? human.message;
+    return (
+      <div className={winClass}>
+        <div className={styles.errorBadge} aria-hidden="true">
+          <RetryIcon size={22} />
+        </div>
+        <p className={styles.headline}>{title}</p>
+        <p className={styles.sub} role="alert">
+          {message}
+        </p>
+        {showAction && human.retryable && onRetry ? (
+          <ActionButton variant="primary" onClick={onRetry} icon={<RetryIcon size={15} strokeWidth={2} />}>
+            Try again
+          </ActionButton>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className={winClass}>
+      <p className={styles.srOnly} aria-live="polite">
+        Score {roundedScore} of {threshold}. {verified ? "Above the threshold." : `${toGo} to go.`}
+      </p>
+
+      {ringButton}
+
+      {verified ? (
+        compact ? (
+          // mini: no standalone verified line. The verified state folds into the
+          // CTA itself (check + "You're verified"), which continues on tap. Ring
+          // + this one button + footer, nothing else, to save vertical space.
+          // With showAction={false} it becomes a static, non-interactive line.
+          showAction ? (
+            <button type="button" className={styles.cta} onClick={onContinue}>
+              <span className={styles.ctaIcon}>
+                <CheckIcon size={15} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>{headline ?? "You're verified"}</span>
+            </button>
+          ) : (
+            <div className={`${styles.verifiedLine} ${reduced ? styles.verifiedLineStatic : ""}`}>
+              <span className={styles.inlineSeal} aria-hidden="true">
+                <CheckIcon size={14} strokeWidth={2.6} />
+              </span>
+              <span className={styles.verifiedText}>{headline ?? "You're verified"}</span>
+            </div>
+          )
+        ) : (
+          <>
+            <div className={`${styles.verifiedLine} ${reduced ? styles.verifiedLineStatic : ""}`}>
+              {/* The external seal / check now sits inline with the headline, and
+                  animates in together with the text. Its tooltip carries the
+                  "Score N. Above the threshold" detail, and it is tappable. */}
+              <Tooltip
+                content={
+                  <>
+                    <b>Score {roundedScore}.</b> Above the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+                  </>
+                }
+                placement="top"
+                className={glass.tip}
+              >
+                <button
+                  type="button"
+                  className={styles.inlineSeal}
+                  onClick={onDrilldown}
+                  aria-label={`Score ${roundedScore}. Above the threshold. Tap to see how it's computed.`}
+                >
+                  <CheckIcon size={14} strokeWidth={2.6} />
+                </button>
+              </Tooltip>
+              <span className={styles.verifiedText}>{headline ?? "You're verified"}</span>
+            </div>
+
+            {showAction ? (
+              <button type="button" className={styles.cta} onClick={onContinue}>
+                <span className={styles.ctaIcon}>
+                  <CheckIcon size={15} strokeWidth={2} />
+                </span>
+                <span className={styles.ctaLabel}>{continueLabel ?? "Continue"}</span>
+              </button>
+            ) : null}
+          </>
+        )
+      ) : (
+        <>
+          <p className={styles.headline}>{headline ?? "Almost verified"}</p>
+          {compact ? null : <p className={styles.sub}>{subtext ?? "You need a little more to pass."}</p>}
+
+          {compact ? null : (
+            <div className={styles.toGo}>
+              <span className={styles.toGoBar}>
+                <i style={{ width: `${Math.min(100, fill * 100)}%` }} />
+              </span>
+              <span className={styles.toGoLabel}>{toGo} to go</span>
+            </div>
+          )}
+
+          {showAction ? (
+            <div className={styles.actions}>
+              {addCta.hidden ? null : (
+                <ActionButton
+                  variant="primary"
+                  onClick={addCta.onClick}
+                  icon={<PlusIcon size={15} strokeWidth={2} />}
+                >
+                  {addCta.label ?? "Add verifications"}
+                </ActionButton>
+              )}
+              {/* mini keeps only the primary action so it stays half-size. */}
+              {compact || idCta.hidden ? null : (
+                <ActionButton
+                  variant="secondary"
+                  onClick={idCta.onClick}
+                  icon={<LinkIcon size={15} strokeWidth={1.9} />}
+                >
+                  {idCta.label ?? "Link an identity"}
+                </ActionButton>
+              )}
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/redesign/SecuredByFooter.module.css
+++ b/src/redesign/SecuredByFooter.module.css
@@ -1,0 +1,33 @@
+/*
+ * Shared "Secured by human.tech" lockup. Consistent icon, font, size, position,
+ * and margin so it renders identically in every shell state (§ harmonized
+ * footer). No hard lines: separation from content is spacing only.
+ */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: var(--space-4-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgba(var(--on-surface), 0.7);
+}
+
+/* Compact form for the single-row pill: smaller mark + text, tight top margin so
+ * the whole widget still reads as one short pill (§ pill footer). */
+.compact {
+  gap: 4px;
+  margin-top: var(--space-2-c6dbf459);
+  font-size: calc(var(--font-size-xs-c6dbf459) * 0.9);
+}
+
+.mark {
+  display: block;
+  opacity: 0.75;
+}
+
+.text {
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.01em;
+}

--- a/src/redesign/SecuredByFooter.tsx
+++ b/src/redesign/SecuredByFooter.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styles from "./SecuredByFooter.module.css";
+import { ShieldIcon } from "./icons";
+
+/**
+ * SecuredByFooter - the single shared "Secured by human.tech" lockup (§ shell
+ * chrome). One component, one icon + font + size + position + margin, so the
+ * footer is byte-for-byte identical across every shell state (score, account,
+ * drill-down, loading, error). Import this everywhere the lockup appears; never
+ * re-inline the icon + text.
+ */
+export const SecuredByFooter: React.FC<{ className?: string; compact?: boolean }> = ({
+  className = "",
+  compact = false,
+}) => (
+  <div className={`${styles.footer} ${compact ? styles.compact : ""} ${className}`}>
+    <ShieldIcon className={styles.mark} size={compact ? 10 : 12} />
+    <span className={styles.text}>Secured by human.tech</span>
+  </div>
+);

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -1,0 +1,591 @@
+/*
+ * StampDetailDrawer - a passport-style slide-in drawer over the Stamps window
+ * (SOP §4). A scrim dims + blurs the grid behind; the drawer is a solid glass
+ * bottom sheet that slides up. Tokens only (§1), legible in both themes (§2/§8),
+ * structure from space + tone not hard lines (§ no-hard-lines), paginate never
+ * scroll (§ windows), all motion degrades under reduced-motion (§4). Everything
+ * lives INSIDE the shell content region: the overlay fills its container and
+ * clips the sliding sheet; nothing escapes the shell.
+ */
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- scrim: the ONE translucent layer. Dims + blurs the grid behind. ---- */
+.scrim {
+  appearance: none;
+  border: 0;
+  position: absolute;
+  inset: 0;
+  padding: 0;
+  cursor: pointer;
+  /* Veil toward the surface so the grid recedes in BOTH themes (washes out on a
+   * white surface, darkens on a near-black one), plus a soft blur for depth. */
+  background: rgba(var(--surface), 0.55);
+  -webkit-backdrop-filter: blur(3px) saturate(1.05);
+  backdrop-filter: blur(3px) saturate(1.05);
+  opacity: 0;
+  transition: opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.overlay[data-open="true"] .scrim {
+  opacity: 1;
+}
+
+/* ---- the sheet: a solid glass drawer that slides up from the bottom ---- */
+/* Leaves a strip of dimmed grid visible at the top so it reads as a drawer over
+ * the window, not a full replacement. Absolutely bottom-pinned with a definite
+ * height, so the inner flex column can pin the action area to the bottom. */
+.drawer {
+  position: absolute;
+  top: var(--space-3-c6dbf459);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2-c6dbf459) var(--space-3-c6dbf459) 0;
+  border-radius: var(--radius-lg-c6dbf459) var(--radius-lg-c6dbf459) 0 0;
+  /* Elevated, near-opaque surface: lifts off the scrim as a distinct layer in
+   * both themes (darkens slightly on white, lightens slightly on near-black),
+   * so content stays legible over the blurred grid without stacking translucency.
+   * Blur + shadow carry the separation instead of a hard border. */
+  background:
+    linear-gradient(rgba(var(--on-surface), 0.05), rgba(var(--on-surface), 0.05)),
+    rgba(var(--surface), 0.98);
+  box-shadow:
+    0 -10px 30px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  /* Slide up from below (transform none at rest so a tooltip trigger inside is
+   * never trapped in a transformed containing block). */
+  transform: translateY(102%);
+  opacity: 0;
+  transition:
+    transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.overlay[data-open="true"] .drawer {
+  transform: none;
+  opacity: 1;
+}
+/* First-mount enter: fade + slide even when mounted already open (§ panels fade,
+ * never pop). */
+@starting-style {
+  .overlay[data-open="true"] .drawer {
+    transform: translateY(102%);
+    opacity: 0;
+  }
+  .overlay[data-open="true"] .scrim {
+    opacity: 0;
+  }
+}
+
+/* ---- handle row: drag handle (a close affordance) + back button ---- */
+.handleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  flex: none;
+}
+.handle {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: var(--space-1-c6dbf459) 0;
+  cursor: pointer;
+  border-radius: var(--radius-md-c6dbf459);
+}
+.handleBar {
+  width: 34px;
+  height: 4px;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.22);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.handle:hover .handleBar {
+  background: rgba(var(--on-surface), 0.36);
+}
+.handle:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.back {
+  appearance: none;
+  border: 0;
+  position: relative;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.66);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Invisible >=40px hit target (a11y §8): 26px + 2×7px = 40px. */
+.back::before {
+  content: "";
+  position: absolute;
+  inset: -7px;
+}
+.back:hover {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.back:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+/* Balances the back button so the handle stays optically centered. */
+.handleSpacer {
+  width: 26px;
+  flex: none;
+}
+
+/* ---- header: medallion + name + total points + on-chain status pill ---- */
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3-c6dbf459);
+  flex: none;
+  margin-top: var(--space-1-c6dbf459);
+}
+.headMeta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+  min-width: 0;
+}
+.name {
+  margin: 0;
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.headSub {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  min-width: 0;
+}
+
+/* On-chain status pill: the ONE carrier of on-chain state in the header (the
+ * medallion drops its pip). Colored by state; a small glass tooltip explains it. */
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px 2px 6px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  cursor: help;
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.08);
+}
+.statusPill:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.statusDot {
+  width: 15px;
+  height: 15px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  background: rgba(var(--on-surface), 0.2);
+  color: rgb(var(--on-surface));
+}
+.statusPill[data-onchain="minted"] {
+  background: rgba(var(--accent), 0.16);
+}
+.statusPill[data-onchain="minted"] .statusDot {
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+}
+.statusPill[data-onchain="mintable"] {
+  background: rgba(var(--warn), 0.18);
+}
+.statusPill[data-onchain="mintable"] .statusDot {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-warn));
+}
+.statusPill[data-onchain="none"] {
+  color: rgba(var(--on-surface), 0.72);
+}
+
+.headPoints {
+  flex: none;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgba(var(--on-surface), 0.8);
+  font-variant-numeric: tabular-nums;
+}
+
+/* One plain description line, clamped so it never grows the fixed header. */
+.desc {
+  margin: var(--space-2-c6dbf459) 0 0;
+  flex: none;
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ---- sub-credential rows: grow to fill, pushing the pager + action down ---- */
+.list {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+  margin-top: var(--space-3-c6dbf459);
+  align-content: flex-start;
+  /* Safety only: the page size is tuned so rows always fit, so this never has to
+   * clip. It guarantees a scrollbar can NEVER appear inside the shell (§ never
+   * scroll), even if an integrator overrides componentsPerPage too high. */
+  overflow: hidden;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  /* Tonal band, not a hard line (§ no-hard-lines). */
+  background: rgba(var(--on-surface), 0.05);
+}
+.row[data-verified="false"] {
+  background: rgba(var(--on-surface), 0.03);
+}
+.rowIcon {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border-radius: var(--radius-sm-c6dbf459);
+  display: grid;
+  place-items: center;
+  font-size: 15px;
+  line-height: 1;
+  color: rgba(var(--on-surface), 0.82);
+  background: rgba(var(--on-surface), 0.07);
+}
+.row[data-verified="false"] .rowIcon {
+  opacity: 0.6;
+}
+.rowMeta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+.rowName {
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rowState {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+  white-space: nowrap;
+}
+.rowPoints {
+  flex: none;
+  padding: 1px 8px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--on-surface), 0.7);
+  background: rgba(var(--on-surface), 0.1);
+}
+.row[data-verified="true"] .rowPoints {
+  color: rgb(var(--on-accent));
+  background: rgb(var(--accent));
+}
+
+/* ---- pager: dots + arrows, never a scrollbar (matches the Stamps window) ---- */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 0;
+  flex: none;
+}
+.pagerArrow {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- how the score is computed: weighted components summing to the total ---- */
+.compute {
+  flex: none;
+  margin-top: var(--space-3-c6dbf459);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+}
+.computeHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2-c6dbf459);
+}
+.computeLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.04em;
+  color: rgba(var(--on-surface), 0.62);
+}
+.computeTotal {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  color: rgb(var(--on-surface));
+  font-variant-numeric: tabular-nums;
+}
+/* The weighted bar: segment LENGTH encodes each component's share; one accent
+ * family (deriveTints), no legend (points ride on the rows above). */
+.computeBar {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  height: 8px;
+  border-radius: var(--radius-pill-c6dbf459);
+  overflow: hidden;
+  background: rgba(var(--on-surface), 0.08);
+}
+.computeSeg {
+  height: 100%;
+  min-width: 3px;
+  border-radius: var(--radius-pill-c6dbf459);
+}
+
+/* ---- action area: bottom-pinned, one primary action + optional renew ---- */
+.actions {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 var(--space-3-c6dbf459);
+}
+/* Two actions (primary + renew) share ONE row so the drawer keeps its single
+ * action-row height whether or not renew is present (no vertical jump, no clip). */
+.actionsRow {
+  flex-direction: row;
+  align-items: stretch;
+}
+.actionsRow > .cta,
+.actionsRow > .doneRow {
+  flex: 1;
+}
+.actionsRow > .ctaRenew {
+  flex: none;
+  width: auto;
+  padding: 0 var(--space-3-c6dbf459);
+}
+
+/* ONE shared button box (matches the Score / Stamps windows). Emerald primary by
+ * default; the reward variant is gold; the secondary is tonal. Only color shifts. */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.ctaIcon {
+  display: inline-flex;
+}
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Gold reward CTA: the mint action. Warm gold (the same amber "reward" token as
+ * the mintable pip), legible black-on-gold text in both themes. */
+.ctaReward {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-warn));
+}
+.ctaReward:focus-visible {
+  outline-color: rgb(var(--warn));
+}
+
+/* Secondary (renew): tonal, no hard line, quieter than the primary. */
+.ctaSecondary {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  box-shadow: none;
+}
+.ctaSecondary:hover {
+  filter: none;
+  background: rgba(var(--on-surface), 0.12);
+}
+/* Renew is the compact tonal step beside the primary (see .actionsRow). */
+.ctaRenew {
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+/* Verified "done" state: a calm confirmation, not a CTA (nothing left to do). It
+ * occupies the same bottom-pinned slot so the layout does not jump between states. */
+.doneRow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  height: 46px;
+  border-radius: var(--radius-lg-c6dbf459);
+  background: rgba(var(--accent), 0.12);
+}
+.doneSeal {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-accent));
+  background: radial-gradient(circle at 35% 28%, rgba(255, 255, 255, 0.9), rgb(var(--accent)) 80%);
+  box-shadow: var(--shadow-sm-c6dbf459);
+}
+.doneText {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrim,
+  .drawer,
+  .handleBar,
+  .cta,
+  .back,
+  .pagerArrow,
+  .pagerDot {
+    transition: none;
+  }
+}

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { StampDetailDrawer } from "./StampDetailDrawer";
+import { StampsWindow } from "./StampsWindow";
+import { PassportShell } from "./PassportShell";
+import {
+  ThemePair,
+  SAMPLE_ACCOUNT,
+  SAMPLE_MEDALLION_STAMPS,
+  SAMPLE_STAMP_DETAILS,
+} from "./storyFrame";
+
+/**
+ * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
+ * window (modeled on app.passport.xyz's stamp drawer). A scrim dims and blurs the
+ * grid behind; the drawer slides up as a solid glass sheet with a drag handle.
+ * Header: medallion + name + total points + on-chain status pill. Then the
+ * sub-credential rows (each with its own points + verified / expiry + icon),
+ * paginated never scrolled. Then how the score is computed (the weighted
+ * components summing to the total). Then one bottom-pinned state-driven action
+ * (Mint / Claim / View on chain / Verified). Both themes, no network, everything
+ * inside the shell.
+ */
+const meta: Meta<typeof StampDetailDrawer> = {
+  title: "Redesign/Stamp Detail",
+  component: StampDetailDrawer,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof StampDetailDrawer>;
+
+// The stage fills the shell content region and positions the drawer overlay, so
+// the drawer slides in over the Stamps window and stays inside the shell bounds.
+const Stage: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div
+    style={{
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 0,
+      width: "100%",
+      display: "flex",
+      flexDirection: "column",
+    }}
+  >
+    {children}
+  </div>
+);
+
+const noop = () => undefined;
+
+/** Compose a static Stamps window behind an open drawer, in both themes. */
+const drawerOver = (
+  detail: (typeof SAMPLE_STAMP_DETAILS)[string],
+  props: Partial<React.ComponentProps<typeof StampDetailDrawer>> = {}
+) => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT}>
+      <Stage>
+        <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} pageSize={6} onSelectStamp={noop} onVerify={noop} />
+        <StampDetailDrawer
+          stamp={detail}
+          onClose={noop}
+          onMint={noop}
+          onClaim={noop}
+          onViewOnchain={noop}
+          {...props}
+        />
+      </Stage>
+    </PassportShell>
+  </ThemePair>
+);
+
+export const VerifiedMinted: Story = {
+  name: "Stamp detail / Verified and minted",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["gov-id"], { onRenew: noop }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A verified, minted stamp. The header medallion drops its own chip and pip, so the points and the on-chain state are each stated once (the total points text and the emerald Minted pill). Three verified components list with their points and renewal, and the weighted bar shows them summing to the total. The minted state resolves to a View on chain action, with a quiet Renew beneath it since a component renews.",
+      },
+    },
+  },
+};
+
+export const MintableReward: Story = {
+  name: "Stamp detail / Mintable (Mint reward)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["biometric"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A verified stamp that can be minted on chain. The status pill is gold (Mintable) and the bottom-pinned action is the gold Mint reward CTA. One primary action, so no secondary competes with the reward.",
+      },
+    },
+  },
+};
+
+export const Unverified: Story = {
+  name: "Stamp detail / Unverified (Claim)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["phone"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An unverified stamp. Its components read as not verified yet, the header shows zero points earned so far, and the how-it-computes bar is omitted because nothing is earned. The action resolves to Claim, so the state is never a dead end.",
+      },
+    },
+  },
+};
+
+export const CleanHands: Story = {
+  name: "Stamp detail / Clean Hands SBT",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["clean-hands"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Proof of Clean Hands SBT (journeys 2 and 5). A verified, mintable credential proving a wallet is clear of sanctions and watchlists. The plain description avoids crypto jargon, and the action is the gold Mint reward so the user can put the SBT on chain.",
+      },
+    },
+  },
+};
+
+export const PaginatedComponents: Story = {
+  name: "Stamp detail / Paginated components",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["reputation"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Six components spill past one page, so the list paginates with dots and arrows. There is no scrollbar (an absolute SOP rule). The how-it-computes bar and the bottom-pinned action stay fixed while the component rows page, since the total is the same whichever page is shown.",
+      },
+    },
+  },
+};
+
+// ---- interactive: tap a medallion in the Stamps window to open its drawer ----
+const InteractiveStage: React.FC = () => {
+  const [openId, setOpenId] = useState<string | null>(null);
+  const detail = openId ? SAMPLE_STAMP_DETAILS[openId] : undefined;
+  return (
+    <Stage>
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        pageSize={6}
+        onSelectStamp={setOpenId}
+        onVerify={noop}
+      />
+      {detail ? (
+        <StampDetailDrawer
+          stamp={detail}
+          onClose={() => setOpenId(null)}
+          onMint={noop}
+          onClaim={noop}
+          onViewOnchain={noop}
+          onRenew={noop}
+        />
+      ) : null}
+    </Stage>
+  );
+};
+
+export const Interactive: Story = {
+  name: "Stamp detail / Interactive (tap a medallion)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <InteractiveStage />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tap any medallion in the Stamps window to slide its detail drawer in over the grid. The scrim dims and blurs the grid behind; tap the scrim, the drag handle, the back arrow, or press Escape to close. Each stamp resolves to its own action: minted stamps view on chain, mintable stamps mint the reward, off-chain verified stamps show Verified, and unverified stamps claim.",
+      },
+    },
+  },
+};

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -1,0 +1,439 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./StampDetailDrawer.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import { Medallion, type Stamp, type StampOnchain } from "./StampsWindow";
+import {
+  ArrowLeftIcon,
+  CaretDownIcon,
+  CheckIcon,
+  ClockIcon,
+  LinkIcon,
+  PlusIcon,
+  RetryIcon,
+  StarIcon,
+} from "./icons";
+import { deriveTints } from "./deriveTints";
+import { useAccentRgb, useReducedMotion } from "./hooks";
+import type { ShellSize } from "./PassportShell";
+
+/**
+ * One sub-credential that contributes to a stamp's score. Each is a row in the
+ * drawer with its own points, verified / expiry state, and an icon.
+ */
+export type StampComponent = {
+  /** Short component name, e.g. "Government ID number" or "Liveness check". */
+  name: string;
+  /** Points this component contributes to the stamp's total. */
+  points: number;
+  /** Whether this component is verified (earned) or still missing. */
+  verified: boolean;
+  /**
+   * Plain expiry / renewal line for a verified component, e.g. "Renews Aug 3" or
+   * "Expired". Kept plain, no crypto jargon, no dashes. Omit when not relevant.
+   */
+  expiry?: string;
+  /** Optional row icon (an emoji, an <img>, or an icon node). */
+  icon?: React.ReactNode;
+};
+
+/**
+ * A stamp with the detail-drawer payload: the components used to score it and an
+ * optional plain description. Extends the Stamps window `Stamp` so the same id /
+ * name / points / verified / onchain / icon carry through.
+ */
+export type StampDetail = Stamp & {
+  /** The components / sub-credentials that were used to score this stamp. */
+  components: StampComponent[];
+  /** Optional plain one-line description of what the stamp proves. */
+  description?: string;
+};
+
+/** The bottom-pinned action the drawer resolves to. One primary action. */
+export type StampAction = "mint" | "claim" | "view" | "verified";
+
+export type StampDetailDrawerProps = {
+  /** The stamp being detailed (header + components + action derive from it). */
+  stamp: StampDetail;
+  /**
+   * Whether the drawer is shown. Default true. When false the overlay stays
+   * mounted but slides down and fades out (pointer-events off), so a parent can
+   * animate it closed instead of unmounting. Consumers may also just conditionally
+   * mount it; the enter animation plays either way.
+   */
+  open?: boolean;
+  /**
+   * Size variant, mirrors the shell's, used only to tune density (components per
+   * page + medallion size). The drawer always fills its container. Default full.
+   */
+  size?: ShellSize;
+  /** Components shown per page before the list paginates (never scrolls). */
+  componentsPerPage?: number;
+
+  /** Close the drawer (scrim tap, drag handle, close button, Escape). */
+  onClose?: () => void;
+  /** Mint the stamp on-chain (the gold reward action when mintable). */
+  onMint?: () => void;
+  /** Claim / verify the stamp (unverified). */
+  onClaim?: () => void;
+  /** View the minted stamp on-chain. */
+  onViewOnchain?: () => void;
+  /** Renew an expiring credential. Shown as a quiet secondary when provided. */
+  onRenew?: () => void;
+
+  /** Force the primary action state, overriding the derived one. */
+  actionState?: StampAction;
+  /** Label overrides for each action (dev-overridable copy). */
+  mintLabel?: string;
+  claimLabel?: string;
+  viewOnchainLabel?: string;
+  verifiedLabel?: string;
+  renewLabel?: string;
+
+  /** Override the on-chain status pill's glass tooltip copy. */
+  statusTooltip?: React.ReactNode;
+};
+
+const ONCHAIN_PILL: Record<StampOnchain, string> = {
+  minted: "Minted",
+  mintable: "Mintable",
+  none: "Off chain",
+};
+
+const ONCHAIN_TIP: Record<StampOnchain, string> = {
+  minted: "This stamp is recorded on chain.",
+  mintable: "You can mint this stamp on chain to earn the reward.",
+  none: "This stamp lives off chain. Nothing is written on chain.",
+};
+
+// Conservative so a page's rows always fit the fixed shell height alongside the
+// header, the how-computed bar, and the bottom-pinned action, with the rest of
+// the components moving to the next page (paginate, never scroll).
+const DEFAULT_PER_PAGE: Record<ShellSize, number> = { full: 2, mini: 2, pill: 2 };
+
+/** Derive the single primary action from the stamp state (dev-overridable). */
+const deriveAction = (stamp: StampDetail, override?: StampAction): StampAction => {
+  if (override) return override;
+  if (!stamp.verified) return "claim";
+  if (stamp.onchain === "mintable") return "mint";
+  if (stamp.onchain === "minted") return "view";
+  return "verified";
+};
+
+/** Split a flat list into fixed-size pages (mirrors the Stamps window pager). */
+const paginate = <T,>(items: T[], per: number): T[][] => {
+  if (per <= 0) return [items];
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += per) pages.push(items.slice(i, i + per));
+  return pages.length ? pages : [[]];
+};
+
+/** One sub-credential row: icon + name + verified / expiry line + points chip. */
+const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) => {
+  const { name, points, verified, expiry, icon } = component;
+  const state = verified ? (expiry ? expiry : "Verified") : "Not verified yet";
+  return (
+    <div className={styles.row} data-verified={verified ? "true" : "false"}>
+      <span className={styles.rowIcon} aria-hidden="true">
+        {icon ?? <StarIcon size={15} strokeWidth={1.6} />}
+      </span>
+      <span className={styles.rowMeta}>
+        <span className={styles.rowName}>{name}</span>
+        <span className={styles.rowState}>
+          {verified ? (
+            expiry ? (
+              <ClockIcon size={11} strokeWidth={1.9} />
+            ) : (
+              <CheckIcon size={11} strokeWidth={2.2} />
+            )
+          ) : null}
+          {state}
+        </span>
+      </span>
+      <span className={styles.rowPoints}>+{points}</span>
+    </div>
+  );
+};
+
+/** Reused pager: dots + arrows, never a scrollbar (matches the Stamps window). */
+const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => void }> = ({
+  page,
+  pageCount,
+  onPage,
+}) => (
+  <div className={styles.pager} role="group" aria-label="Component pages">
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.max(0, page - 1))}
+      disabled={page === 0}
+      aria-label="Previous components"
+    >
+      <CaretDownIcon className={styles.pagerPrev} size={13} />
+    </button>
+    <span className={styles.pagerDots}>
+      {Array.from({ length: pageCount }).map((_, i) => (
+        <button
+          type="button"
+          key={i}
+          className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+          onClick={() => onPage(i)}
+          aria-label={`Component page ${i + 1}`}
+          aria-current={i === page ? "true" : undefined}
+        />
+      ))}
+    </span>
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.min(pageCount - 1, page + 1))}
+      disabled={page === pageCount - 1}
+      aria-label="More components"
+    >
+      <CaretDownIcon className={styles.pagerNext} size={13} />
+    </button>
+  </div>
+);
+
+/**
+ * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
+ * window (SOP §4, modeled on app.passport.xyz's stamp drawer). A scrim dims and
+ * blurs the grid behind; the drawer slides up from the bottom as a solid glass
+ * sheet with a drag handle. Header carries the medallion + name + total points +
+ * on-chain status pill; then the sub-credential rows (each with its own points +
+ * verified / expiry + icon), paginated never scrolled; then how the score is
+ * computed (the weighted components summing to the total); then one bottom-pinned
+ * state-driven action (Mint / Claim / View on chain / Verified) plus an optional
+ * renew. Presentational: props only, both-theme legible, reduced-motion aware,
+ * everything inside the shell.
+ */
+export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
+  stamp,
+  open = true,
+  size = "full",
+  componentsPerPage,
+  onClose,
+  onMint,
+  onClaim,
+  onViewOnchain,
+  onRenew,
+  actionState,
+  mintLabel,
+  claimLabel,
+  viewOnchainLabel,
+  verifiedLabel,
+  renewLabel,
+  statusTooltip,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const accent = useAccentRgb(rootRef);
+  const [page, setPage] = useState(0);
+
+  // Escape closes the drawer while it is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const per = componentsPerPage ?? DEFAULT_PER_PAGE[size];
+  const pages = useMemo(() => paginate(stamp.components, per), [stamp.components, per]);
+  const pageCount = pages.length;
+  const current = Math.min(page, pageCount - 1);
+  const pageComponents = pages[current] ?? [];
+
+  // Earned total = sum of the verified components' points. This is the number the
+  // header states and the weighted bar sums to (one source, no hardcoded total).
+  const earned = useMemo(
+    () => stamp.components.reduce((a, c) => a + (c.verified ? c.points : 0), 0),
+    [stamp.components]
+  );
+
+  // How the score is computed: the verified components as accent-derived segments
+  // whose LENGTH is each one's share of the total. One hue family, no rainbow, no
+  // legend (points ride on the rows above). Ranked so the largest reads deepest.
+  const segments = useMemo(() => {
+    const verified = stamp.components.filter((c) => c.verified && c.points > 0);
+    const denom = verified.reduce((a, c) => a + c.points, 0) || 1;
+    const ranked = verified.slice().sort((a, b) => b.points - a.points);
+    const tints = deriveTints(accent, verified.length);
+    return verified.map((c) => ({
+      name: c.name,
+      pct: (c.points / denom) * 100,
+      color: tints[Math.max(0, ranked.indexOf(c))],
+    }));
+  }, [stamp.components, accent]);
+
+  const action = deriveAction(stamp, actionState);
+  const showRenew = Boolean(onRenew) && stamp.verified && action !== "claim";
+
+  const compact = size !== "full";
+  const medallionPx = compact ? 40 : 46;
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.overlay}
+      data-open={open ? "true" : "false"}
+      role="dialog"
+      aria-modal="false"
+      aria-label={`${stamp.name} details`}
+    >
+      {/* Scrim: the ONE translucent layer. Dims + blurs the grid behind and closes
+          the drawer on tap. The drawer sheet on top is solid so content stays
+          legible (materials rule: never stack translucent layers to mush). */}
+      <button
+        type="button"
+        className={styles.scrim}
+        aria-label="Close stamp details"
+        tabIndex={open ? 0 : -1}
+        onClick={onClose}
+      />
+
+      <section className={styles.drawer}>
+        {/* Drag handle doubles as a close affordance; an explicit back button sits
+            beside it for keyboard users. */}
+        <div className={styles.handleRow}>
+          <button
+            type="button"
+            className={styles.back}
+            onClick={onClose}
+            tabIndex={open ? 0 : -1}
+            aria-label="Back to stamps"
+          >
+            <ArrowLeftIcon size={13} />
+          </button>
+          <button
+            type="button"
+            className={styles.handle}
+            onClick={onClose}
+            tabIndex={open ? 0 : -1}
+            aria-label="Close stamp details"
+          >
+            <span className={styles.handleBar} aria-hidden="true" />
+          </button>
+          <span className={styles.handleSpacer} aria-hidden="true" />
+        </div>
+
+        {/* Header: clean medallion (no chip / pip, so points + on-chain are stated
+            once, below) + name + total points + on-chain status pill. */}
+        <header className={styles.header}>
+          <Medallion stamp={stamp} showPoints={false} showPip={false} sizePx={medallionPx} />
+          <div className={styles.headMeta}>
+            <h3 className={styles.name}>{stamp.name}</h3>
+            <div className={styles.headSub}>
+              <Tooltip content={statusTooltip ?? ONCHAIN_TIP[stamp.onchain]} placement="top" className={glass.tip}>
+                <span
+                  className={styles.statusPill}
+                  data-onchain={stamp.onchain}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`${ONCHAIN_PILL[stamp.onchain]}. ${
+                    statusTooltip ? "" : ONCHAIN_TIP[stamp.onchain]
+                  }`}
+                >
+                  <span className={styles.statusDot} aria-hidden="true">
+                    {stamp.onchain === "none" ? null : <LinkIcon size={9} strokeWidth={2} />}
+                  </span>
+                  {ONCHAIN_PILL[stamp.onchain]}
+                </span>
+              </Tooltip>
+              <span className={styles.headPoints}>{earned} points</span>
+            </div>
+          </div>
+        </header>
+
+        {stamp.description ? <p className={styles.desc}>{stamp.description}</p> : null}
+
+        {/* Sub-credential rows, paginated (never scrolled). */}
+        <div className={styles.list}>
+          <p className={styles.srOnly} aria-live="polite">
+            {stamp.components.length} components. Page {current + 1} of {pageCount}.
+          </p>
+          {pageComponents.map((c, i) => (
+            <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
+          ))}
+        </div>
+
+        {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+
+        {/* How the score is computed: the weighted components summing to the total.
+            Length encodes each share; one accent family; the total on the right. */}
+        {segments.length ? (
+          <div className={styles.compute}>
+            <div className={styles.computeHead}>
+              <span className={styles.computeLabel}>How your points add up</span>
+              <span className={styles.computeTotal}>{earned} points</span>
+            </div>
+            <div
+              className={styles.computeBar}
+              role="img"
+              aria-label={`The verified components sum to ${earned} points.`}
+            >
+              {segments.map((seg, i) => (
+                <span
+                  key={`${seg.name}-${i}`}
+                  className={styles.computeSeg}
+                  style={{ width: `${seg.pct}%`, background: seg.color }}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {/* Action area: bottom-pinned, one primary action, state-driven. When a
+            renew is shown it sits BESIDE the primary on one row (not stacked), so
+            the two-action case reserves no extra height inside the fixed shell. */}
+        <div className={`${styles.actions} ${showRenew ? styles.actionsRow : ""}`}>
+          {action === "mint" ? (
+            <button type="button" className={`${styles.cta} ${styles.ctaReward}`} onClick={onMint}>
+              <span className={styles.ctaIcon}>
+                <StarIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{mintLabel ?? "Mint reward"}</span>
+            </button>
+          ) : action === "claim" ? (
+            <button type="button" className={styles.cta} onClick={onClaim}>
+              <span className={styles.ctaIcon}>
+                <PlusIcon size={15} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>{claimLabel ?? "Claim stamp"}</span>
+            </button>
+          ) : action === "view" ? (
+            <button type="button" className={styles.cta} onClick={onViewOnchain}>
+              <span className={styles.ctaIcon}>
+                <LinkIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{viewOnchainLabel ?? "View on chain"}</span>
+            </button>
+          ) : (
+            <div className={styles.doneRow}>
+              <span className={styles.doneSeal} aria-hidden="true">
+                <CheckIcon size={14} strokeWidth={2.6} />
+              </span>
+              <span className={styles.doneText}>{verifiedLabel ?? "Verified"}</span>
+            </div>
+          )}
+
+          {/* Renewal, where relevant. Quiet tonal secondary, never the primary. */}
+          {showRenew ? (
+            <button
+              type="button"
+              className={`${styles.cta} ${styles.ctaSecondary} ${styles.ctaRenew}`}
+              onClick={onRenew}
+            >
+              <span className={styles.ctaIcon}>
+                <RetryIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{renewLabel ?? "Renew"}</span>
+            </button>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/redesign/StampsWindow.module.css
+++ b/src/redesign/StampsWindow.module.css
@@ -1,0 +1,480 @@
+/*
+ * StampsWindow - stamps as glass medallion plaques (SOP §4). Each stamp is a real
+ * badge (conic rim + embossed face + depth + a corner pip), grouped by category
+ * (tonal header, no hard line), paginated and NEVER scrolled. Tokens only (§1),
+ * legible in both themes (§2/§8), motion degrades under reduced-motion (§4).
+ */
+
+.window {
+  display: flex;
+  flex-direction: column;
+  /* Fill the shell's fixed content height so switching tabs never jumps and the
+   * verify CTA bottom-pins at the same y as the other windows' primary CTA. */
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- header: title + a quiet verified count. Tonal, no hard line. ---- */
+.head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+}
+.title {
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+.count {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- paged region: grows to fill, pushing the pager + CTA to the bottom. ---- */
+.pages {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3-c6dbf459);
+  margin-top: var(--space-3-c6dbf459);
+  align-content: flex-start;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+}
+
+/* Category header: tone + space, never a rule (§ no-hard-lines). */
+.catHead {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.55);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  column-gap: var(--space-2-c6dbf459);
+  row-gap: var(--space-3-c6dbf459);
+}
+
+/* ---- one badge: medallion + name, the whole thing is the tap target ---- */
+.badge {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) 2px var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  color: inherit;
+  font-family: inherit;
+  transition: transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.badge:hover {
+  transform: translateY(-1px);
+}
+.badge:hover .medallion {
+  filter: brightness(1.05);
+}
+.badge:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- the medallion: rim (conic) + embossed face + depth ---- */
+.medallion {
+  --rd-med: 50px;
+  position: relative;
+  width: var(--rd-med);
+  height: var(--rd-med);
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  /* rim: a soft metallic ring drawn as a conic gradient behind the face. Neutral
+   * (unearned) by default; emerald when verified. Padding reveals it as the rim. */
+  padding: 2px;
+  background: conic-gradient(
+    from 210deg,
+    rgba(var(--on-surface), 0.05),
+    rgba(var(--on-surface), 0.2),
+    rgba(var(--on-surface), 0.05),
+    rgba(var(--on-surface), 0.16),
+    rgba(var(--on-surface), 0.05)
+  );
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  transition: filter var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.medallion[data-verified="true"] {
+  background: conic-gradient(
+    from 210deg,
+    rgba(var(--accent), 0.35),
+    rgba(var(--accent), 0.9),
+    rgba(var(--accent), 0.4),
+    rgba(var(--accent), 0.85),
+    rgba(var(--accent), 0.35)
+  );
+}
+
+.face {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.85);
+  /* embossed plate: a top-left highlight + inset depth so it reads as struck
+   * metal, not a flat disc. */
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.35), transparent 55%),
+    rgb(var(--surface));
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.22),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.12);
+}
+.medallion[data-verified="true"] .face {
+  color: rgb(var(--on-surface));
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.42), transparent 55%),
+    linear-gradient(160deg, rgba(var(--accent), 0.24), rgba(var(--accent), 0.1));
+}
+/* Unverified reads quieter: the face art recedes so earned badges stand out. */
+.medallion[data-verified="false"] .glyph {
+  opacity: 0.6;
+}
+
+.glyph {
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  line-height: 1;
+}
+
+/* Corner on-chain pip: the ONE carrier of on-chain state. A surface-colored ring
+ * punches it off the medallion (a notch, not a divider). */
+.pip {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 0 2px rgb(var(--surface));
+}
+.medallion[data-onchain="minted"] .pip {
+  color: rgb(var(--on-accent));
+  background: rgb(var(--accent));
+}
+.medallion[data-onchain="mintable"] .pip {
+  color: rgb(var(--on-accent));
+  /* gold: reuse the amber "attention / available" semantic token. */
+  background: rgb(var(--warn));
+}
+.medallion[data-onchain="none"] .pip {
+  background: rgba(var(--on-surface), 0.16);
+}
+
+/* Points chip: overlaps the medallion foot like a badge ribbon. Emerald when
+ * earned (verified), muted when the points are still only available. */
+.points {
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  background: rgba(var(--on-surface), 0.14);
+  color: rgba(var(--on-surface), 0.72);
+}
+.medallion[data-verified="true"] .points {
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  box-shadow: var(--shadow-sm-c6dbf459);
+}
+
+.name {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgb(var(--on-surface));
+  text-align: center;
+  max-width: 100%;
+  /* Reserve two lines so every badge row is the SAME height whether a name wraps
+   * or not. This keeps the paged region's height deterministic, so nothing spills
+   * the fixed shell height (§ nothing outside the shell / never scroll). */
+  min-height: calc(2 * var(--font-size-xs-c6dbf459) * var(--line-tight-c6dbf459));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ---- empty / loading center ---- */
+.center {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3-c6dbf459);
+  text-align: center;
+}
+.emptyMark {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.6);
+  background: rgba(var(--on-surface), 0.06);
+}
+.emptyText {
+  margin: 0;
+  max-width: 220px;
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  text-wrap: balance;
+}
+
+.loaderWrap {
+  display: grid;
+  place-items: center;
+}
+.spin {
+  animation: rdSpin 1s linear infinite;
+  transform-origin: center;
+}
+@keyframes rdSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---- pager: dots + arrows, never a scrollbar (matches the shell pager) ---- */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 0;
+}
+.pagerArrow {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- verify CTA: same box metric + emerald primary as the Score window ---- */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  margin-top: var(--space-3-c6dbf459);
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.ctaIcon {
+  display: inline-flex;
+}
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* Inline (auto-width) CTA used by the pill row. */
+.ctaInline {
+  width: auto;
+  flex: none;
+  height: 34px;
+  margin-top: 0;
+  padding: 0 var(--space-3-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+/* ---- mini: condensed half card. Smaller medallions, one header, no CTA. ---- */
+.miniWin .grid {
+  row-gap: var(--space-3-c6dbf459);
+}
+.medallionSm {
+  --rd-med: 42px;
+}
+.medallionSm .glyph {
+  font-size: 16px;
+}
+.medallionSm .points {
+  bottom: -5px;
+  padding: 0 6px;
+}
+.medallionSm .pip {
+  width: 15px;
+  height: 15px;
+}
+.miniWin .name {
+  -webkit-line-clamp: 1;
+  min-height: calc(var(--font-size-xs-c6dbf459) * var(--line-tight-c6dbf459));
+}
+
+/* ---- pill: one short status row: mini stack + count + one action. ---- */
+.pillWin {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+}
+.pillStack {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+}
+/* Overlap the mini medallions into a compact cluster. */
+.pillStack .medallion {
+  margin-right: -12px;
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    0 0 0 2px rgb(var(--surface));
+}
+.pillStack .medallion:last-child {
+  margin-right: 0;
+}
+/* The pill has no room for the points ribbon; keep the stack to face + pip. */
+.pillStack .points {
+  display: none;
+}
+.pillText {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge,
+  .medallion,
+  .cta,
+  .pagerArrow,
+  .pagerDot {
+    transition: none;
+  }
+  .spin {
+    animation: none;
+  }
+}

--- a/src/redesign/StampsWindow.stories.tsx
+++ b/src/redesign/StampsWindow.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { StampsWindow } from "./StampsWindow";
+import { PassportShell } from "./PassportShell";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS, SAMPLE_MEDALLION_STAMPS_PAGED } from "./storyFrame";
+
+/**
+ * StampsWindow - stamps as glass medallion plaques, grouped by category and
+ * paginated (never scrolled), composed inside the shell so the overlay rules
+ * (nothing outside the shell, no scrollbar, badges read as medallions) are
+ * visible. Both themes, no network.
+ */
+const meta: Meta<typeof StampsWindow> = {
+  title: "Redesign/Stamps Window",
+  component: StampsWindow,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof StampsWindow>;
+
+const inShell = (node: React.ReactNode, size?: "full" | "mini" | "pill") => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT} size={size}>
+      {node}
+    </PassportShell>
+  </ThemePair>
+);
+
+export const FullGrid: Story = {
+  name: "Stamps / Full grid",
+  render: () =>
+    inShell(
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        pageSize={6}
+        onSelectStamp={() => undefined}
+        onVerify={() => undefined}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The medallion catalog: a mix of verified and unverified stamps, minted and mintable and off-chain. Each stamp is a glass badge with a conic rim, an embossed face, a points chip, and a corner on-chain pip (emerald minted, gold mintable, muted off-chain). Stamps group under tonal category headers. Tapping a badge fires onSelectStamp (the detail drawer is a later slice). A bottom-pinned emerald verify CTA matches the Score window's primary action.",
+      },
+    },
+  },
+};
+
+export const Paginated: Story = {
+  name: "Stamps / Paginated (two pages)",
+  render: () =>
+    inShell(
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS_PAGED}
+        onSelectStamp={() => undefined}
+        onVerify={() => undefined}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Ten stamps spill past one page, so the window paginates with dots and arrows. There is no scrollbar (an absolute SOP rule): overflow is split across pages, never scrolled. Each page regroups its own stamps under category headers.",
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: "Stamps / Empty",
+  render: () => inShell(<StampsWindow stamps={[]} onVerify={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "No stamps yet. A calm centered prompt with a single verify CTA, so the state is never a dead end. The shell height stays fixed so switching to a populated tab does not jump.",
+      },
+    },
+  },
+};
+
+export const Mini: Story = {
+  name: "Stamps / Mini",
+  render: () =>
+    inShell(<StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onSelectStamp={() => undefined} size="mini" />, "mini"),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The condensed half-size card: smaller medallions, one row per page, category headers dropped to save space. It shares the shell's fixed mini height.",
+      },
+    },
+  },
+};
+
+export const Pill: Story = {
+  name: "Stamps / Pill",
+  render: () =>
+    inShell(
+      <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onVerify={() => undefined} size="pill" />,
+      "pill"
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The single-row pill: a compact cluster of mini medallions, a stamp count, and one inline verify action. It summarizes rather than lists, so it never scrolls or paginates.",
+      },
+    },
+  },
+};

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -101,16 +101,44 @@ const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stam
   return order.map((category) => ({ category, stamps: map.get(category)! }));
 };
 
+export type MedallionProps = {
+  /** The stamp whose face, on-chain pip, and points chip to render. */
+  stamp: Stamp;
+  /** Condensed ~half-size medallion (mini card). */
+  compact?: boolean;
+  /** Show the overlapping points chip. Default true. The drawer header carries
+   *  the total as its own text, so it renders the medallion WITHOUT the chip to
+   *  avoid stating the points twice (one carrier per signal). */
+  showPoints?: boolean;
+  /** Show the corner on-chain pip. Default true. The drawer header carries the
+   *  on-chain state in its status pill instead, so it drops the medallion pip. */
+  showPip?: boolean;
+  /** Override the diameter (px). Sets --rd-med inline (wins over the size rule). */
+  sizePx?: number;
+};
+
 /**
  * A single glass medallion: a rim + embossed face carrying the stamp icon, a
  * corner on-chain pip, and a points chip. Verified vs not is carried by the face
  * / rim tone; on-chain by the pip; points by the chip. One signal per meaning.
+ *
+ * Exported so the stamp detail drawer reuses the exact medallion look for its
+ * header (a shared primitive, not a duplicated treatment). The header passes
+ * showPoints/showPip false so the same on-chain + points signal is not stated
+ * twice (§ no redundancy).
  */
-const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compact }) => (
+export const Medallion: React.FC<MedallionProps> = ({
+  stamp,
+  compact,
+  showPoints = true,
+  showPip = true,
+  sizePx,
+}) => (
   <span
     className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
     data-verified={stamp.verified ? "true" : "false"}
     data-onchain={stamp.onchain}
+    style={sizePx ? ({ "--rd-med": `${sizePx}px` } as React.CSSProperties) : undefined}
   >
     <span className={styles.face}>
       <span className={styles.glyph} aria-hidden="true">
@@ -119,10 +147,12 @@ const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compa
     </span>
     {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
         to the chain (minted / mintable); "none" is a recessive muted disc. */}
-    <span className={styles.pip} aria-hidden="true">
-      {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
-    </span>
-    <span className={styles.points}>+{stamp.points}</span>
+    {showPip ? (
+      <span className={styles.pip} aria-hidden="true">
+        {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+      </span>
+    ) : null}
+    {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
   </span>
 );
 

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -1,0 +1,365 @@
+import React, { useMemo, useState } from "react";
+import styles from "./StampsWindow.module.css";
+import { CaretDownIcon, LinkIcon, PlusIcon, StarIcon } from "./icons";
+import { useReducedMotion } from "./hooks";
+import type { ShellSize } from "./PassportShell";
+
+/**
+ * On-chain state of a stamp, carried by ONE signal (the corner pip):
+ *  - "minted"   the stamp is recorded on-chain (emerald chain pip)
+ *  - "mintable" the stamp can be minted on-chain (gold chain pip)
+ *  - "none"     the stamp lives off-chain (muted, recessive pip)
+ */
+export type StampOnchain = "minted" | "mintable" | "none";
+
+export type Stamp = {
+  /** Stable id passed back through onSelectStamp. */
+  id: string;
+  /** Short stamp name, e.g. "Government ID". */
+  name: string;
+  /** Grouping label, e.g. "Identity" / "Biometrics" / "Social". */
+  category: string;
+  /** Points this stamp contributes to the score (earned when verified). */
+  points: number;
+  /** Whether the credential is verified (earned) or still available to add. */
+  verified: boolean;
+  /** On-chain state. Drives the medallion's corner pip only (one signal). */
+  onchain: StampOnchain;
+  /** Optional badge face art (an emoji, an <img>, or an icon node). */
+  icon?: React.ReactNode;
+};
+
+export type StampsWindowProps = {
+  /** The stamps to show, grouped by category and paginated (never scrolled). */
+  stamps: Stamp[];
+  /** Tapping a badge fires this with the stamp id (the detail drawer is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /**
+   * The verify / add entry point (bottom-pinned primary CTA, consistent with the
+   * shell's "Add verifications"). Omit to drop the CTA entirely.
+   */
+  onVerify?: () => void;
+  /** Override the verify CTA label. */
+  verifyLabel?: string;
+  /** Badges per page before it paginates. Defaults to 6 (full) / 3 (mini). */
+  pageSize?: number;
+  /** Override the header label. Defaults to "Your stamps". */
+  headline?: string;
+  /** Empty-state message. Defaults to a plain "No stamps yet" line. */
+  emptyLabel?: string;
+  /**
+   * Interim loading state. Reuses the ScoreWindow ScoreLoader approach (a simple
+   * indeterminate emerald arc); it does NOT invent a new loader or pull Cryptex.
+   */
+  loading?: boolean;
+  /**
+   * Size variant, mirrors the shell's. Pass the SAME value you pass to
+   * PassportShell so the fixed height matches and the tab-switch never jumps.
+   */
+  size?: ShellSize;
+};
+
+// Kept small so a page never renders more medallion rows than the shell's fixed
+// height holds (each category becomes its own row, so few-item categories add up
+// fast). Stories that show a denser single page pass an explicit larger pageSize.
+const DEFAULT_PAGE_SIZE: Record<ShellSize, number> = { full: 4, mini: 3, pill: 3 };
+
+const ONCHAIN_LABEL: Record<StampOnchain, string> = {
+  minted: "Minted on chain",
+  mintable: "Can be minted on chain",
+  none: "Off chain",
+};
+
+/** Plain-language points phrase for the accessible name (earned vs available). */
+const pointsPhrase = (s: Stamp) =>
+  s.verified ? `${s.points} points earned` : `${s.points} points available`;
+
+const stampLabel = (s: Stamp) =>
+  `${s.name}. ${pointsPhrase(s)}. ${s.verified ? "Verified" : "Not verified yet"}. ${
+    ONCHAIN_LABEL[s.onchain]
+  }. Open stamp.`;
+
+/** Split a flat list into fixed-size pages. */
+const paginate = <T,>(items: T[], per: number): T[][] => {
+  if (per <= 0) return [items];
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += per) pages.push(items.slice(i, i + per));
+  return pages.length ? pages : [[]];
+};
+
+/** Group a page's stamps by category, preserving first-appearance order. */
+const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stamp[] }> => {
+  const order: string[] = [];
+  const map = new Map<string, Stamp[]>();
+  for (const s of items) {
+    if (!map.has(s.category)) {
+      map.set(s.category, []);
+      order.push(s.category);
+    }
+    map.get(s.category)!.push(s);
+  }
+  return order.map((category) => ({ category, stamps: map.get(category)! }));
+};
+
+/**
+ * A single glass medallion: a rim + embossed face carrying the stamp icon, a
+ * corner on-chain pip, and a points chip. Verified vs not is carried by the face
+ * / rim tone; on-chain by the pip; points by the chip. One signal per meaning.
+ */
+const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compact }) => (
+  <span
+    className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
+    data-verified={stamp.verified ? "true" : "false"}
+    data-onchain={stamp.onchain}
+  >
+    <span className={styles.face}>
+      <span className={styles.glyph} aria-hidden="true">
+        {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
+      </span>
+    </span>
+    {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
+        to the chain (minted / mintable); "none" is a recessive muted disc. */}
+    <span className={styles.pip} aria-hidden="true">
+      {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+    </span>
+    <span className={styles.points}>+{stamp.points}</span>
+  </span>
+);
+
+/**
+ * Interim loader, mirroring ScoreWindow's ScoreLoader (a simple indeterminate
+ * emerald arc). Not a new loader, and NOT the Cryptex loader (see ScoreWindow /
+ * design-sop §7 reuse-shared-components): the shared loader is consumed as a
+ * dependency once installable, never vendored into this public repo.
+ */
+const StampsLoader: React.FC = () => {
+  const reduced = useReducedMotion();
+  return (
+    <div className={styles.loaderWrap} role="status" aria-label="Loading your stamps">
+      <svg width={44} height={44} viewBox="0 0 48 48" aria-hidden className={reduced ? undefined : styles.spin}>
+        <circle cx="24" cy="24" r="20" fill="none" stroke="rgba(var(--muted), 0.25)" strokeWidth="4" />
+        <path d="M24 4 a20 20 0 0 1 20 20" fill="none" stroke="rgb(var(--accent))" strokeWidth="4" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+};
+
+/** Reused pager: dots + arrows, never a scrollbar (matches the shell pager). */
+const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => void }> = ({
+  page,
+  pageCount,
+  onPage,
+}) => (
+  <div className={styles.pager} role="group" aria-label="Stamp pages">
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.max(0, page - 1))}
+      disabled={page === 0}
+      aria-label="Previous stamps"
+    >
+      <CaretDownIcon className={styles.pagerPrev} size={13} />
+    </button>
+    <span className={styles.pagerDots}>
+      {Array.from({ length: pageCount }).map((_, i) => (
+        <button
+          type="button"
+          key={i}
+          className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+          onClick={() => onPage(i)}
+          aria-label={`Stamp page ${i + 1}`}
+          aria-current={i === page ? "true" : undefined}
+        />
+      ))}
+    </span>
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.min(pageCount - 1, page + 1))}
+      disabled={page === pageCount - 1}
+      aria-label="More stamps"
+    >
+      <CaretDownIcon className={styles.pagerNext} size={13} />
+    </button>
+  </div>
+);
+
+/**
+ * StampsWindow - the medallion catalog, rendered INSIDE PassportShell like the
+ * Score window. Stamps are glass plaques grouped by category, paginated and never
+ * scrolled (§4 / §Windows). Presentational: props only, no data hooks, both-theme
+ * legible, reduced-motion aware. Tapping a badge fires onSelectStamp; the detail
+ * drawer is a later slice.
+ */
+export const StampsWindow: React.FC<StampsWindowProps> = ({
+  stamps,
+  onSelectStamp,
+  onVerify,
+  verifyLabel,
+  pageSize,
+  headline,
+  emptyLabel,
+  loading = false,
+  size = "full",
+}) => {
+  const [page, setPage] = useState(0);
+  const per = pageSize ?? DEFAULT_PAGE_SIZE[size];
+  const compact = size !== "full";
+
+  const pages = useMemo(() => paginate(stamps, per), [stamps, per]);
+  const pageCount = pages.length;
+  const current = Math.min(page, pageCount - 1);
+  const pageStamps = pages[current] ?? [];
+  const groups = useMemo(() => groupByCategory(pageStamps), [pageStamps]);
+
+  const verifiedCount = useMemo(() => stamps.filter((s) => s.verified).length, [stamps]);
+
+  const winClass = `${styles.window} ${size === "mini" ? styles.miniWin : ""} ${
+    size === "pill" ? styles.pillWin : ""
+  }`;
+
+  // ---- pill: one short status row. Up to three mini medallions, a count, and
+  // one compact action. No category headers, no pager (the pill summarizes). ----
+  if (size === "pill") {
+    // Two preview medallions keep the single row from crowding the count + action
+    // at the 300px pill width (the third would push the label into an ellipsis).
+    const preview = stamps.slice(0, 2);
+    return (
+      <div className={winClass}>
+        {loading ? (
+          <>
+            <StampsLoader />
+            <span className={styles.pillText}>Loading your stamps</span>
+          </>
+        ) : (
+          <>
+            <span className={styles.pillStack} aria-hidden="true">
+              {preview.map((s) => (
+                <Medallion key={s.id} stamp={s} compact />
+              ))}
+            </span>
+            <span className={styles.pillText}>
+              {verifiedCount}/{stamps.length} verified
+            </span>
+            {onVerify ? (
+              <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onVerify}>
+                <span className={styles.ctaIcon}>
+                  <PlusIcon size={14} strokeWidth={2} />
+                </span>
+                <span className={styles.ctaLabel}>{verifyLabel ?? "Verify"}</span>
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className={winClass}>
+        <div className={styles.head}>
+          <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        </div>
+        <div className={styles.center}>
+          <StampsLoader />
+          <p className={styles.emptyText}>Loading your stamps</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!stamps.length) {
+    return (
+      <div className={winClass}>
+        <div className={styles.head}>
+          <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        </div>
+        <div className={styles.center}>
+          <span className={styles.emptyMark} aria-hidden="true">
+            <StarIcon size={22} strokeWidth={1.6} />
+          </span>
+          <p className={styles.emptyText}>{emptyLabel ?? "No stamps yet. Verify one to start your passport."}</p>
+        </div>
+        {onVerify ? (
+          <button type="button" className={styles.cta} onClick={onVerify}>
+            <span className={styles.ctaIcon}>
+              <PlusIcon size={15} strokeWidth={2} />
+            </span>
+            <span className={styles.ctaLabel}>{verifyLabel ?? "Verify a stamp"}</span>
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className={winClass}>
+      <p className={styles.srOnly} aria-live="polite">
+        {stamps.length} stamps, {verifiedCount} verified. Page {current + 1} of {pageCount}.
+      </p>
+
+      <div className={styles.head}>
+        <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        <span className={styles.count}>
+          {verifiedCount}/{stamps.length} verified
+        </span>
+      </div>
+
+      <div className={styles.pages}>
+        {compact ? (
+          // mini stays simpler: one flat grid, no category headers, so the
+          // half-size card keeps to a single medallion row per page.
+          <div className={styles.grid}>
+            {pageStamps.map((s) => (
+              <button
+                type="button"
+                key={s.id}
+                className={styles.badge}
+                onClick={() => onSelectStamp?.(s.id)}
+                aria-label={stampLabel(s)}
+              >
+                <Medallion stamp={s} compact />
+                <span className={styles.name}>{s.name}</span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          groups.map((group) => (
+            <div className={styles.group} key={group.category}>
+              {/* Category header: tonal text + space, no hard line (§ no-hard-lines). */}
+              <div className={styles.catHead}>{group.category}</div>
+              <div className={styles.grid}>
+                {group.stamps.map((s) => (
+                  <button
+                    type="button"
+                    key={s.id}
+                    className={styles.badge}
+                    onClick={() => onSelectStamp?.(s.id)}
+                    aria-label={stampLabel(s)}
+                  >
+                    <Medallion stamp={s} />
+                    <span className={styles.name}>{s.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+
+      {/* Bottom-pinned verify entry, consistent with the shell's primary CTA. mini
+          stays simpler and drops it to keep the half-size card uncluttered. */}
+      {onVerify && !compact ? (
+        <button type="button" className={styles.cta} onClick={onVerify}>
+          <span className={styles.ctaIcon}>
+            <PlusIcon size={15} strokeWidth={2} />
+          </span>
+          <span className={styles.ctaLabel}>{verifyLabel ?? "Verify more stamps"}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/src/redesign/deriveTints.ts
+++ b/src/redesign/deriveTints.ts
@@ -1,0 +1,95 @@
+/**
+ * Palette derivation for the score drill-down (SOP §4).
+ *
+ * The drill-down arcs draw ONLY from the embed's accent - one hue family,
+ * stepped tints/shades. No rainbow, no invented colors, no legend. These
+ * helpers take the accent color and produce N legible mid-tone tints, ordered
+ * so the largest contribution gets the base hue and deeper ranks step within
+ * the same family.
+ *
+ * Lightness is deliberately clamped to a mid band so the arcs (and the white
+ * points that ride on them) stay legible in BOTH light and dark themes - the
+ * accent's own lightness varies by theme, but the derived arc lightness does
+ * not.
+ */
+
+export type RGB = [number, number, number];
+
+/** Parse an "r, g, b" CSS triplet (the shape our color tokens use). */
+export const parseRgbTriplet = (value: string): RGB | null => {
+  const m = value.trim().match(/(\d+(?:\.\d+)?)\D+(\d+(?:\.\d+)?)\D+(\d+(?:\.\d+)?)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+};
+
+export const rgbToHsl = ([r, g, b]: RGB): [number, number, number] => {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / d + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / d + 2;
+        break;
+      default:
+        h = (rn - gn) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return [h, s * 100, l * 100];
+};
+
+export const hslToRgb = (h: number, s: number, l: number): RGB => {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = ln - c / 2;
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+};
+
+const DEFAULT_ACCENT: RGB = [16, 185, 129]; // Human Passport emerald (#10B981)
+
+/**
+ * Derive `count` arc colors from `accent`, ranked (index 0 = largest slice).
+ * ONE hue family (SOP §4, "no rainbow"): the accent's hue and saturation are
+ * held fixed and only LIGHTNESS steps per rank, so every arc reads as the same
+ * emerald - no hue-rotation drift toward teal/green. Lightness stays in a mid
+ * band so the white points that ride on each arc stay legible in both themes.
+ */
+export const deriveTints = (accent: RGB | null, count: number): string[] => {
+  const base = accent ?? DEFAULT_ACCENT;
+  const [h, s] = rgbToHsl(base);
+  const hue = h; // fixed - never rotated
+  const sat = Math.min(Math.max(s, 55), 80);
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    // Largest slice (i=0) is the deepest tone; deeper ranks step lighter within
+    // the same emerald family. Clamped to a mid band (≤72) for point legibility.
+    const light = Math.min(44 + i * 6, 72);
+    const [r, g, b] = hslToRgb(hue, sat, light);
+    out.push(`rgb(${r}, ${g}, ${b})`);
+  }
+  return out;
+};

--- a/src/redesign/glassTip.module.css
+++ b/src/redesign/glassTip.module.css
@@ -1,0 +1,50 @@
+/*
+ * Glass tooltip skin for the redesign (§ materials / tooltips-become-glass).
+ *
+ * Passed as `className` to the shared <Tooltip>, so it layers onto the tooltip's
+ * own `.tooltip` element WITHOUT editing the shipped Tooltip module (which the
+ * live widget still uses). Translucent + blurred material, soft, no hard border.
+ *
+ * Legibility first (§8, >=4.5:1): the tooltip floats over unknown host content,
+ * so a single translucent layer is not enough on its own. We stack a near-opaque
+ * surface SCRIM (0.9 of --surface) under the blur, so the text always sits on a
+ * strong, on-theme backdrop while the edges still read as glass. `--on-surface`
+ * over 0.9 `--surface` clears AA in both themes.
+ */
+.tip {
+  /* override the shipped solid surface + 1px border with glass */
+  background:
+    linear-gradient(rgba(var(--surface), 0.9), rgba(var(--surface), 0.9)),
+    rgba(var(--surface), 0.6) !important;
+  border: 0 !important;
+  color: rgb(var(--on-surface)) !important;
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+  box-shadow:
+    0 8px 30px rgba(0, 0, 0, 0.22),
+    inset 0 0 0 1px rgba(var(--on-surface), 0.06) !important;
+  font-size: var(--font-size-sm-c6dbf459) !important;
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-normal-c6dbf459) !important;
+  max-width: 240px !important;
+}
+
+/* The arrow is the tooltip's LAST child div (after the .content div). Reskin it
+ * to match the glass and drop its hard border, without reaching into the other
+ * module's hashed class name. */
+.tip > div:last-child {
+  background: rgba(var(--surface), 0.9) !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+/* Emphasis + the "tap to see how it's computed" tail read a touch quieter. */
+.tip b,
+.tip strong {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+.tip em {
+  font-style: normal;
+  color: rgba(var(--on-surface), 0.72);
+}

--- a/src/redesign/hooks.ts
+++ b/src/redesign/hooks.ts
@@ -1,0 +1,63 @@
+import { RefObject, useEffect, useState } from "react";
+import { parseRgbTriplet, RGB } from "./deriveTints";
+
+/** True when the user asked for reduced motion. SSR-safe. */
+export const useReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+};
+
+/**
+ * Resolve the widget's `--accent` token (an "r, g, b" triplet) from a mounted
+ * element, so derived palettes stay in lock-step with whatever theme the host
+ * passed. Falls back to an explicit override, then to null (deriveTints seeds a
+ * default).
+ */
+export const useAccentRgb = (ref: RefObject<HTMLElement>, override?: string): RGB | null => {
+  const [rgb, setRgb] = useState<RGB | null>(() => (override ? parseRgbTriplet(override) : null));
+  useEffect(() => {
+    if (override) {
+      setRgb(parseRgbTriplet(override));
+      return;
+    }
+    if (typeof window === "undefined" || !ref.current) return;
+    const resolved = getComputedStyle(ref.current).getPropertyValue("--accent");
+    const parsed = parseRgbTriplet(resolved);
+    if (parsed) setRgb(parsed);
+  }, [ref, override]);
+  return rgb;
+};
+
+/**
+ * Animated count-up from 0 to `target`. Returns the current display value.
+ * Collapses to the final value instantly under reduced-motion.
+ */
+export const useCountUp = (target: number, durationMs: number, reduced: boolean): number => {
+  const [value, setValue] = useState(reduced ? target : 0);
+  useEffect(() => {
+    if (reduced || typeof window === "undefined" || !window.requestAnimationFrame) {
+      setValue(target);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / durationMs, 1);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(target * eased);
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, durationMs, reduced]);
+  return value;
+};

--- a/src/redesign/humanizeError.ts
+++ b/src/redesign/humanizeError.ts
@@ -1,0 +1,87 @@
+/*
+ * humanizeError - map a failure to friendly, human copy (§ score states / copy).
+ *
+ * The score window NEVER shows a raw `error.message`. Every failure is mapped to
+ * a short title, a plain one-sentence explanation, and whether a retry is worth
+ * offering. Callers pass either a known kind or an unknown thrown value (an axios
+ * error, a DOMException, a string); we sniff the kind from it. Copy is deliberately
+ * simple and dash free.
+ */
+
+export type ErrorKind = "network" | "rate-limit" | "timeout" | "unknown";
+
+export type HumanError = {
+  kind: ErrorKind;
+  /** Short headline for the error state. */
+  title: string;
+  /** One plain sentence the user can act on. */
+  message: string;
+  /** Whether a retry affordance should be shown. */
+  retryable: boolean;
+};
+
+const COPY: Record<ErrorKind, Omit<HumanError, "kind">> = {
+  network: {
+    title: "No connection",
+    message: "We could not reach the network. Check your connection and try again.",
+    retryable: true,
+  },
+  "rate-limit": {
+    title: "Too many requests",
+    message: "You have made a lot of requests. Wait a moment, then try again.",
+    retryable: true,
+  },
+  timeout: {
+    title: "This is taking too long",
+    message: "The request timed out before we heard back. Try again.",
+    retryable: true,
+  },
+  unknown: {
+    title: "Something went wrong",
+    message: "We could not load your score just now. Try again.",
+    retryable: true,
+  },
+};
+
+/** Best-effort sniff of an error kind from an unknown thrown value. */
+export const classifyError = (input: unknown): ErrorKind => {
+  if (input == null) return "unknown";
+
+  // A numeric-ish status (429) anywhere on the value.
+  const status =
+    typeof input === "object" && input !== null
+      ? // axios shape: err.response.status, or err.status
+        (input as { response?: { status?: number }; status?: number }).response?.status ??
+        (input as { status?: number }).status
+      : undefined;
+  if (status === 429) return "rate-limit";
+  if (status === 408 || status === 504) return "timeout";
+
+  const text = (
+    typeof input === "string"
+      ? input
+      : input instanceof Error
+        ? `${input.name} ${input.message}`
+        : (() => {
+            try {
+              return JSON.stringify(input);
+            } catch {
+              return String(input);
+            }
+          })()
+  ).toLowerCase();
+
+  if (/429|rate.?limit|too many/.test(text)) return "rate-limit";
+  if (/time?out|timed out|deadline|abort/.test(text)) return "timeout";
+  if (/network|failed to fetch|offline|dns|econn|enotfound|connection/.test(text)) return "network";
+  return "unknown";
+};
+
+/** Map a kind, or an unknown thrown value, to friendly error copy. */
+export const humanizeError = (input: ErrorKind | unknown): HumanError => {
+  const kind: ErrorKind =
+    input === "network" || input === "rate-limit" || input === "timeout" || input === "unknown"
+      ? input
+      : classifyError(input);
+  return { kind, ...COPY[kind] };
+};

--- a/src/redesign/icons.tsx
+++ b/src/redesign/icons.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+
+/**
+ * Small stroke-icon set for the redesign shell + score windows.
+ *
+ * Every icon draws with `stroke: currentColor` (via the shared `gl` styling on
+ * the consuming CSS module), so an icon inherits the token-driven color of its
+ * context and is legible in BOTH themes. No hardcoded fills/strokes here.
+ */
+
+type IconProps = {
+  className?: string;
+  size?: number;
+  strokeWidth?: number;
+  title?: string;
+};
+
+const Svg: React.FC<IconProps & { children: React.ReactNode; viewBox?: string }> = ({
+  className,
+  size = 16,
+  strokeWidth = 1.6,
+  title,
+  viewBox = "0 0 24 24",
+  children,
+}) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox={viewBox}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    role={title ? "img" : "presentation"}
+    aria-hidden={title ? undefined : true}
+    aria-label={title}
+    focusable="false"
+  >
+    {title ? <title>{title}</title> : null}
+    {children}
+  </svg>
+);
+
+/** Placeholder integrator app-icon (a cube). */
+export const CubeIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 2.5 21 7v10l-9 4.5L3 17V7z" />
+    <path d="M3 7l9 4.5L21 7" />
+    <path d="M12 11.5V21.5" />
+  </Svg>
+);
+
+export const CaretDownIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M6 9l6 6 6-6" />
+  </Svg>
+);
+
+export const CheckIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M20 6 9 17l-5-5" />
+  </Svg>
+);
+
+export const ShieldIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 2.5 20 6v6c0 5-3.5 8-8 9.5C7.5 20 4 17 4 12V6z" />
+  </Svg>
+);
+
+export const StarIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 3.5l2.6 5.3 5.9.85-4.25 4.15 1 5.85L12 16.9l-5.25 2.75 1-5.85L3.5 9.65l5.9-.85z" />
+  </Svg>
+);
+
+export const InfoIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9.5" />
+    <path d="M12 16.5v-5M12 8h.01" />
+  </Svg>
+);
+
+export const RetryIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M20 11a8 8 0 1 0-1.5 5" />
+    <path d="M20 4.5V11h-6.5" />
+  </Svg>
+);
+
+export const ArrowLeftIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M19 12H5M11 18l-6-6 6-6" />
+  </Svg>
+);
+
+export const SparkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 3v4M12 17v4M4.9 7.4l2.6 2.6M16.5 14l2.6 2.6M3 12h4M17 12h4M4.9 16.6l2.6-2.6M16.5 10l2.6-2.6" />
+  </Svg>
+);
+
+/** Wallet (used for the link-wallet CTA + linked-wallet rows). */
+export const WalletIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H18a2 2 0 0 1 2 2v1H6a1.5 1.5 0 0 0 0 3H20a1 1 0 0 1 1 1v3a2 2 0 0 1-2 2H5.5A2.5 2.5 0 0 1 3 15.5z" />
+    <path d="M16.5 12.5h.01" />
+  </Svg>
+);
+
+/** Plus / add affordance (link additional wallet, add verifications). */
+export const PlusIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 5v14M5 12h14" />
+  </Svg>
+);
+
+/** Copy (two stacked sheets) - copy an address / wallet to the clipboard. */
+export const CopyIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <rect x="9" y="9" width="12" height="12" rx="2.2" />
+    <path d="M6 15H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1" />
+  </Svg>
+);
+
+/** Chain link (link an identity). Two interlocking links, not a wallet. */
+export const LinkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M9.5 14.5 14.5 9.5" />
+    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
+    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
+  </Svg>
+);
+
+/** Unlink (break the chain) - remove a linked wallet. */
+export const UnlinkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
+    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
+    <path d="M3 3l18 18" />
+  </Svg>
+);
+
+/** Small clock (cooldown / pending wallet status). */
+export const ClockIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7.5V12l3 2" />
+  </Svg>
+);
+
+/** Sign out. */
+export const LogoutIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M15 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3" />
+    <path d="M10 17l-5-5 5-5M4 12h11" />
+  </Svg>
+);
+
+/** Switch accounts (two-way). */
+export const SwitchIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M4 8h13l-3-3M20 16H7l3 3" />
+  </Svg>
+);
+
+/**
+ * WaaP mark - the "Wallet as a Passport" account behind the passport. A small
+ * booklet/passport glyph with a quatrefoil-ish humanity dot, drawn on brand and
+ * legible in both themes (currentColor stroke). Not a crop of the full lockup.
+ */
+export const WaaPIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M5 4.5A1.5 1.5 0 0 1 6.5 3H17a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6.5A1.5 1.5 0 0 1 5 19.5z" />
+    <path d="M5 17h12" />
+    <circle cx="12" cy="9" r="2.4" />
+  </Svg>
+);

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Redesign slice 1 - Shell + Score window (SOP §4 / spine.md).
+ *
+ * Presentational, props-only components (no data hooks), rendered alongside the
+ * existing shipped widget. The shipped `PassportScoreWidget` is untouched.
+ */
+export { PassportShell } from "./PassportShell";
+export type {
+  PassportShellProps,
+  ShellAccount,
+  ShellAccountOption,
+  LinkedWallet,
+  LinkedWalletStatus,
+  ShellSize,
+} from "./PassportShell";
+
+export { ScoreWindow } from "./ScoreWindow";
+export type { ScoreWindowProps, ScoreWindowState, ShellCta } from "./ScoreWindow";
+
+export { ScoreDrilldown } from "./ScoreDrilldown";
+export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
+
+export { ScoreHome } from "./ScoreHome";
+export type { ScoreHomeProps } from "./ScoreHome";
+
+export { SecuredByFooter } from "./SecuredByFooter";
+
+export { humanizeError, classifyError } from "./humanizeError";
+export type { ErrorKind, HumanError } from "./humanizeError";

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -23,6 +23,9 @@ export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
 export { ScoreHome } from "./ScoreHome";
 export type { ScoreHomeProps } from "./ScoreHome";
 
+export { StampsWindow } from "./StampsWindow";
+export type { StampsWindowProps, Stamp, StampOnchain } from "./StampsWindow";
+
 export { SecuredByFooter } from "./SecuredByFooter";
 
 export { humanizeError, classifyError } from "./humanizeError";

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -23,8 +23,16 @@ export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
 export { ScoreHome } from "./ScoreHome";
 export type { ScoreHomeProps } from "./ScoreHome";
 
-export { StampsWindow } from "./StampsWindow";
-export type { StampsWindowProps, Stamp, StampOnchain } from "./StampsWindow";
+export { StampsWindow, Medallion } from "./StampsWindow";
+export type { StampsWindowProps, Stamp, StampOnchain, MedallionProps } from "./StampsWindow";
+
+export { StampDetailDrawer } from "./StampDetailDrawer";
+export type {
+  StampDetailDrawerProps,
+  StampDetail,
+  StampComponent,
+  StampAction,
+} from "./StampDetailDrawer";
 
 export { SecuredByFooter } from "./SecuredByFooter";
 

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -116,3 +116,31 @@ export const SAMPLE_STAMPS = [
   { id: "social", label: "Social", points: 5 },
   { id: "onchain", label: "On-chain", points: 3 },
 ];
+
+// Medallion-stamp sample data for the Stamps window. A mix of verified /
+// unverified and minted / mintable / off-chain so every face state is visible.
+// Two categories (three each) so it reads as a full grid on one page. Icons are
+// plain emoji (valid ReactNode) so the stories need no asset pipeline.
+export const SAMPLE_MEDALLION_STAMPS = [
+  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
+  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
+  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
+  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
+  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
+  { id: "x-social", name: "X", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "✖️" },
+];
+
+// A larger catalog that spills past one page (>6), so pagination shows two pages
+// with dots + arrows and the "never scrolled" rule is visible.
+export const SAMPLE_MEDALLION_STAMPS_PAGED = [
+  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
+  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
+  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
+  { id: "biometric", name: "Biometric", category: "Biometrics", points: 5, verified: true, onchain: "minted" as const, icon: "🫆" },
+  { id: "face-scan", name: "Face scan", category: "Biometrics", points: 4, verified: false, onchain: "none" as const, icon: "🙂" },
+  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
+  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
+  { id: "linkedin", name: "LinkedIn", category: "Social", points: 2, verified: false, onchain: "none" as const, icon: "🔗" },
+  { id: "eth-activity", name: "Ethereum activity", category: "On-chain activity", points: 4, verified: true, onchain: "mintable" as const, icon: "⟠" },
+  { id: "gitcoin", name: "Gitcoin", category: "On-chain activity", points: 3, verified: false, onchain: "none" as const, icon: "🌱" },
+];

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { Widget, PassportWidgetTheme } from "../widgets/Widget";
+import { DarkTheme, LightTheme } from "../utils/themes";
+
+/**
+ * Story-only harness. Renders the redesign components inside the REAL widget
+ * root (`Widget`) so the §1 token scope (--surface, --accent, --space-*, …) and
+ * the 300px sizing resolve exactly as they do in a host app - then places that
+ * widget on a light / dark HOST background to prove the "guest on any surface"
+ * rule (SOP §2 / §7). No network: Widget provides its own providers.
+ */
+
+const hostBg: Record<"light" | "dark", string> = {
+  light: "#eef0f4",
+  dark: "#0b0b10",
+};
+
+const Frame: React.FC<{ theme: PassportWidgetTheme; label: string; bg: "light" | "dark"; children: React.ReactNode }> = ({
+  theme,
+  label,
+  bg,
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10 }}>
+    <span
+      style={{
+        fontFamily: "ui-monospace, monospace",
+        fontSize: 11,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: bg === "dark" ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.5)",
+      }}
+    >
+      {label}
+    </span>
+    <div style={{ padding: 24, borderRadius: 20, background: hostBg[bg] }}>
+      <Widget theme={theme}>{children}</Widget>
+    </div>
+  </div>
+);
+
+/** Render the same content in both themes, side by side, each on a matching host background. */
+export const ThemePair: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ display: "flex", gap: 28, flexWrap: "wrap", alignItems: "flex-start" }}>
+    <Frame theme={LightTheme} label="Light theme · light host" bg="light">
+      {children}
+    </Frame>
+    <Frame theme={DarkTheme} label="Dark theme · dark host" bg="dark">
+      {children}
+    </Frame>
+  </div>
+);
+
+export const SAMPLE_ACCOUNT = {
+  display: "Shady.eth",
+  kind: "ENS",
+  email: "shady@holonym.id",
+  address: "0x1332…4a9f",
+  linkedWallets: [
+    // `address` carries the FULL value for the hover-to-copy control, while
+    // `display` stays truncated. Copying yields the complete address.
+    { display: "0x1332…4a9f", kind: "Wallet", address: "0x1332f4c1b9a70d5e2c8a4f6e11c9b3d0aa7e4a9f" },
+    { display: "vault.eth", kind: "ENS", address: "0x77aa20c3e9b1d4f60825ab19c7d3e5f0126b8c11" },
+  ],
+  accounts: [
+    { display: "Shady.eth", kind: "ENS" },
+    { display: "0x1332…4a9f", kind: "Wallet" },
+  ],
+};
+
+const BASE = { display: "Shady.eth", kind: "ENS", email: "shady@holonym.id", address: "0x1332…4a9f" };
+
+/** One linked wallet. */
+export const ACCOUNT_ONE_WALLET = {
+  ...BASE,
+  linkedWallets: [{ display: "0x1332…4a9f", kind: "Wallet" }],
+};
+
+/** Exactly three linked wallets (fills a page, no pager yet). */
+export const ACCOUNT_THREE_WALLETS = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet" },
+    { display: "vault.eth", kind: "ENS" },
+    { display: "0x88b1…02aa", kind: "Wallet" },
+  ],
+};
+
+/** Six linked wallets: paginates into two pages of three (dots + arrows). */
+export const ACCOUNT_SIX_WALLETS = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet" },
+    { display: "vault.eth", kind: "ENS" },
+    { display: "0x88b1…02aa", kind: "Wallet" },
+    { display: "treasury.eth", kind: "ENS" },
+    { display: "0x4c9d…7f10", kind: "Safe" },
+    { display: "0xab20…6d33", kind: "Wallet" },
+  ],
+};
+
+/** A mix including a wallet in cooldown and one still pending. */
+export const ACCOUNT_COOLDOWN = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet", status: "active" as const },
+    { display: "vault.eth", status: "cooldown" as const, cooldownUntil: "Cooldown until Aug 3" },
+    { display: "0x88b1…02aa", status: "pending" as const, cooldownUntil: "Linking in progress" },
+  ],
+};
+
+export const SAMPLE_STAMPS = [
+  { id: "gov-id", label: "Government ID", points: 6 },
+  { id: "biometric", label: "Biometric", points: 5 },
+  { id: "clean-hands", label: "Clean Hands", points: 5 },
+  { id: "social", label: "Social", points: 5 },
+  { id: "onchain", label: "On-chain", points: 3 },
+];

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Widget, PassportWidgetTheme } from "../widgets/Widget";
 import { DarkTheme, LightTheme } from "../utils/themes";
+import type { StampDetail } from "./StampDetailDrawer";
 
 /**
  * Story-only harness. Renders the redesign components inside the REAL widget
@@ -144,3 +145,140 @@ export const SAMPLE_MEDALLION_STAMPS_PAGED = [
   { id: "eth-activity", name: "Ethereum activity", category: "On-chain activity", points: 4, verified: true, onchain: "mintable" as const, icon: "⟠" },
   { id: "gitcoin", name: "Gitcoin", category: "On-chain activity", points: 3, verified: false, onchain: "none" as const, icon: "🌱" },
 ];
+
+// Stamp-detail (drawer) sample data, keyed by the medallion stamp id so a Stamps
+// window story can open the drawer for whichever medallion is tapped. Each detail
+// extends its medallion stamp with the components used to score it (verified ones
+// sum to the header total) and a plain description. A spread of states so every
+// action is visible: minted (View on chain), mintable (Mint reward), unverified
+// (Claim), off-chain verified (Verified / done), and a 6-component paginated case.
+export const SAMPLE_STAMP_DETAILS: Record<string, StampDetail> = {
+  // Verified + minted -> View on chain. Three verified components summing to 6.
+  "gov-id": {
+    id: "gov-id",
+    name: "Government ID",
+    category: "Identity",
+    points: 6,
+    verified: true,
+    onchain: "minted",
+    icon: "🪪",
+    description: "Proof that a government issued ID checked out, without revealing the document.",
+    components: [
+      { name: "Document authenticity", points: 3, verified: true, expiry: "Renews Mar 2027", icon: "📄" },
+      { name: "Liveness check", points: 2, verified: true, icon: "🙂" },
+      { name: "Name match", points: 1, verified: true, icon: "🔤" },
+    ],
+  },
+
+  // Verified + mintable -> Mint reward (gold CTA). This is the Clean Hands SBT.
+  "clean-hands": {
+    id: "clean-hands",
+    name: "Clean Hands",
+    category: "Identity",
+    points: 5,
+    verified: true,
+    onchain: "mintable",
+    icon: "🤝",
+    description: "Proof that your wallet is clear of sanctions and watchlists.",
+    components: [
+      { name: "Sanctions check", points: 3, verified: true, expiry: "Renews Sep 1", icon: "🛡️" },
+      { name: "Watchlist check", points: 2, verified: true, icon: "🔎" },
+    ],
+  },
+
+  // Verified + mintable biometric -> Mint reward. Distinct from Clean Hands so the
+  // Mint story and the Clean Hands story show different stamps.
+  biometric: {
+    id: "biometric",
+    name: "Biometric",
+    category: "Biometrics",
+    points: 5,
+    verified: true,
+    onchain: "mintable",
+    icon: "🫆",
+    description: "Proof of a unique, live human, checked with your camera.",
+    components: [
+      { name: "Face liveness", points: 3, verified: true, icon: "🙂" },
+      { name: "Uniqueness check", points: 2, verified: true, expiry: "Renews Aug 12", icon: "✨" },
+    ],
+  },
+
+  // Unverified -> Claim. Both components still missing (earns 0 until claimed).
+  phone: {
+    id: "phone",
+    name: "Phone",
+    category: "Identity",
+    points: 2,
+    verified: false,
+    onchain: "none",
+    icon: "📱",
+    description: "Verify a phone number you control to add points.",
+    components: [
+      { name: "Phone ownership", points: 2, verified: false, icon: "📱" },
+      { name: "Carrier check", points: 1, verified: false, icon: "📶" },
+    ],
+  },
+
+  // Verified but off-chain with nothing to mint -> the Verified (done) state.
+  github: {
+    id: "github",
+    name: "GitHub",
+    category: "Social",
+    points: 3,
+    verified: true,
+    onchain: "none",
+    icon: "🐙",
+    description: "Proof of an established GitHub account.",
+    components: [
+      { name: "Account age", points: 2, verified: true, expiry: "Renews Jun 2026", icon: "📆" },
+      { name: "Contribution history", points: 1, verified: true, icon: "📈" },
+    ],
+  },
+
+  // Unverified social -> Claim (single component).
+  discord: {
+    id: "discord",
+    name: "Discord",
+    category: "Social",
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: "💬",
+    description: "Verify a Discord account to add a point.",
+    components: [{ name: "Account ownership", points: 1, verified: false, icon: "💬" }],
+  },
+
+  // Unverified social -> Claim (single component).
+  "x-social": {
+    id: "x-social",
+    name: "X",
+    category: "Social",
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: "✖️",
+    description: "Verify an X account to add a point.",
+    components: [{ name: "Account ownership", points: 1, verified: false, icon: "✖️" }],
+  },
+
+  // Minted with SIX components -> the paginated-components case (View on chain).
+  // Three verified (sum to 5) plus three still-available, across two pages.
+  reputation: {
+    id: "reputation",
+    name: "On-chain reputation",
+    category: "On-chain activity",
+    points: 5,
+    verified: true,
+    onchain: "minted",
+    icon: "⟠",
+    description: "Proof of a real, active on-chain history.",
+    components: [
+      { name: "Account age", points: 2, verified: true, expiry: "Renews Jan 2027", icon: "📆" },
+      { name: "Transaction history", points: 2, verified: true, icon: "🔁" },
+      { name: "Token holdings", points: 1, verified: true, icon: "🪙" },
+      { name: "NFT activity", points: 1, verified: false, icon: "🖼️" },
+      { name: "DeFi activity", points: 1, verified: false, icon: "🏦" },
+      { name: "Governance votes", points: 1, verified: false, icon: "🗳️" },
+    ],
+  },
+};

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -2,11 +2,15 @@ import { PassportWidgetTheme } from "../widgets/Widget";
 
 export const DarkTheme: PassportWidgetTheme = {
   colors: {
+    // Human Passport brand: emerald accent (#10B981) on a brand dark surface.
+    // Surface is an emerald-tinted charcoal (#101815), NOT pure black: brand
+    // Neutral-95 (#0A0A0A) warmed toward brand Emerald-95 (#064E3B). It reads as
+    // a deep on-brand surface and lets the emerald paper-shader wash show.
     primary: "255, 255, 255",
-    secondary: "109, 109, 109",
-    background: "0, 0, 0",
-    accent: "0, 212, 170",
-    error: "235, 48, 45",
+    secondary: "115, 115, 115",
+    background: "16, 24, 21",
+    accent: "16, 185, 129",
+    error: "252, 103, 100",
     white: "255, 255, 255",
     black: "0, 0, 0",
   },
@@ -38,12 +42,14 @@ export const DarkTheme: PassportWidgetTheme = {
 export const LightTheme: PassportWidgetTheme = {
   ...DarkTheme,
   colors: {
-    primary: "55, 55, 55",
-    secondary: "200, 200, 200",
+    // Human Passport brand emerald accent (#10B981). primary darkened to near-black
+    // (10,10,10) so secondary/muted text (rgba over primary) clears WCAG-AA ≥4.5:1
+    // on the white surface — previously 55,55,55 which failed at low alphas.
+    primary: "10, 10, 10",
+    secondary: "115, 115, 115",
     background: "255, 255, 255",
-    accent: "113, 248, 194",
-    // Real error red, legible on the light (white) surface. Previously 55,55,55
-    // (grey) which disagreed with the DarkTheme error and read as non-error.
+    accent: "16, 185, 129",
+    // Real error red, legible on the light (white) surface.
     error: "220, 38, 38",
   },
 };

--- a/src/widgets/PassportScoreWidget.stories.tsx
+++ b/src/widgets/PassportScoreWidget.stories.tsx
@@ -87,7 +87,7 @@ const openPlatform = async (root: HTMLElement, platformName: string) => {
 // surface platform variants the default handler doesn't expose (extra Human ID
 // credential types, a signature-only stamp). This overrides only the story's
 // MSW handler set, not the shared mocks.
-const stampsMetadataHandler = (pages: unknown) =>
+const stampsMetadataHandler = (pages: object) =>
   http.get(`${MOCK_SERVICE_URL}/embed/stamps/metadata`, async () => {
     await delay(200);
     return HttpResponse.json(pages);

--- a/src/widgets/Widget.module.css
+++ b/src/widgets/Widget.module.css
@@ -79,7 +79,10 @@
   /* Motion */
   --motion-fast-c6dbf459: 50ms;
   --motion-base-c6dbf459: 200ms;
-  --ease-standard-c6dbf459: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-slow-c6dbf459: 900ms;
+  /* House ease-out (§1/§4). Components inline this same curve; the token is the
+   * single source of truth so the two never drift. */
+  --ease-standard-c6dbf459: cubic-bezier(0.22, 1, 0.36, 1);
 
   /* ---------------------------------------------------------------------
    * Per-role color aliases. Future work overrides ONE semantic name and it
@@ -96,6 +99,31 @@
   --danger: var(--color-error-c6dbf459);
   --on-danger: var(--color-white-c6dbf459);
   --border: var(--color-secondary-c6dbf459);
+
+  /* Semantic below-threshold color (§ score states). A warm amber that reads as
+   * "almost there, not yet passing" and stays legible as a thick ring stroke /
+   * progress fill on BOTH the light (white) and dark (near-black) surfaces.
+   * One token, shared by both themes, so the ring + progress switch amber below
+   * the threshold and emerald at or above it from a single source of truth. */
+  --warn: 245, 158, 11; /* #F59E0B amber-500 */
+  --on-warn: 10, 10, 10;
+
+  /* Paper-shader wash color for the shell field (integrator-configurable via the
+   * PassportShell `washRgb` prop, which sets --rd-wash). Defaults to the accent
+   * so the living-material wash is on-brand emerald out of the box. */
+  --rd-wash: var(--accent);
+
+  /* Shell edge separation. A near-black widget on a DARK host would otherwise
+   * blend into it, so the shell carries its own soft light edge: a hairline
+   * light-alpha inner rim (a glass lip) plus a soft ambient outer glow. Both use
+   * a fixed white alpha so they read as separation on a dark host and simply
+   * fade to nothing on a light host (white glow over white is invisible) — never
+   * a hard outline (§no-hard-lines). Kept subtle and premium. Tokenized here so
+   * the values are single-sourced and re-tunable. */
+  --rd-edge-rim: inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+  --rd-edge-glow:
+    0 0 0 0.5px rgba(255, 255, 255, 0.05),
+    0 6px 26px -2px rgba(255, 255, 255, 0.08);
 
   /* Width will be 300 unless screen
    * is too narrow, in which case it

--- a/test/utils/themes.test.tsx
+++ b/test/utils/themes.test.tsx
@@ -9,13 +9,13 @@ describe("Theme Utils", () => {
     it("includes all required color properties", () => {
       expect(DarkTheme.colors).toBeDefined();
       expect(DarkTheme.colors?.primary).toBe("255, 255, 255");
-      expect(DarkTheme.colors?.secondary).toBe("109, 109, 109");
-      expect(DarkTheme.colors?.background).toBe("0, 0, 0");
-      expect(DarkTheme.colors?.error).toBe("235, 48, 45");
+      expect(DarkTheme.colors?.secondary).toBe("115, 115, 115");
+      expect(DarkTheme.colors?.background).toBe("16, 24, 21");
+      expect(DarkTheme.colors?.error).toBe("252, 103, 100");
     });
 
     it("includes accent color for CTAs", () => {
-      expect(DarkTheme.colors?.accent).toBe("0, 212, 170"); // #00D4AA
+      expect(DarkTheme.colors?.accent).toBe("16, 185, 129"); // #10B981 Human Passport emerald
     });
 
     it("includes padding configuration", () => {
@@ -35,14 +35,14 @@ describe("Theme Utils", () => {
   describe("LightTheme", () => {
     it("includes all required color properties", () => {
       expect(LightTheme.colors).toBeDefined();
-      expect(LightTheme.colors?.primary).toBe("55, 55, 55");
-      expect(LightTheme.colors?.secondary).toBe("200, 200, 200");
+      expect(LightTheme.colors?.primary).toBe("10, 10, 10");
+      expect(LightTheme.colors?.secondary).toBe("115, 115, 115");
       expect(LightTheme.colors?.background).toBe("255, 255, 255");
-      expect(LightTheme.colors?.error).toBe("55, 55, 55");
+      expect(LightTheme.colors?.error).toBe("220, 38, 38");
     });
 
     it("includes accent color for CTAs", () => {
-      expect(LightTheme.colors?.accent).toBe("113, 248, 194"); // #71F8C2 - light theme accent
+      expect(LightTheme.colors?.accent).toBe("16, 185, 129"); // #10B981 Human Passport emerald
     });
 
     it("uses same padding as dark theme", () => {
@@ -106,10 +106,10 @@ describe("Widget setTheme functionality", () => {
 
     // Check all colors are applied
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("255, 255, 255");
-    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("109, 109, 109");
-    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("0, 0, 0");
-    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("0, 212, 170");
-    expect(style.getPropertyValue("--color-error-c6dbf459")).toBe("235, 48, 45");
+    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("115, 115, 115");
+    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("16, 24, 21");
+    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("16, 185, 129");
+    expect(style.getPropertyValue("--color-error-c6dbf459")).toBe("252, 103, 100");
   });
 
   it("handles missing accent color gracefully", () => {
@@ -177,7 +177,7 @@ describe("Widget setTheme functionality", () => {
     let style = window.getComputedStyle(widgetElement);
 
     // Initial theme
-    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("0, 212, 170");
+    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("16, 185, 129");
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("255, 255, 255");
 
     // Real-world usage: spread existing theme and override specific values
@@ -202,8 +202,8 @@ describe("Widget setTheme functionality", () => {
     // Primary should be updated to dimmer white
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("230, 230, 230");
     // Other theme properties should remain from DarkTheme
-    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("0, 0, 0");
-    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("109, 109, 109");
+    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("16, 24, 21");
+    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("115, 115, 115");
   });
 
   it("handles theme with all properties defined", () => {


### PR DESCRIPTION
## What

Slice 3 of the passport-embed redesign: the **Stamp detail drawer**, a passport-style slide-in that opens over the Stamps window (modeled on app.passport.xyz's stamp drawer). Serves flows 1, 2 (Clean Hands), and 5 (mint).

Presentational, props-only, Storybook-first. Does NOT touch `main` or `PassportScoreWidget`, and vendors no private design-system source.

## Components

- `StampDetailDrawer.tsx` / `.module.css` — the drawer
- `StampDetailDrawer.stories.tsx` — stories under `Redesign/Stamp Detail`
- `StampsWindow.tsx` — `Medallion` promoted to a reusable primitive (`showPoints` / `showPip` / `sizePx`, defaults preserve current behavior), reused in the drawer header
- `storyFrame.tsx` — `SAMPLE_STAMP_DETAILS` sample data
- `index.ts` — exports the drawer, its types, and `Medallion`

## Behavior (SOP §4)

- **Slides in over the Stamps window.** A scrim dims + blurs the grid behind (the one translucent layer); the drawer is a solid glass bottom sheet that slides up. Fade-not-pop via `@starting-style`, reduced-motion aware. Drag handle + back button + scrim tap + Escape all close. Everything stays inside the shell.
- **Header:** clean medallion (no chip / pip, so points + on-chain are each stated once) + name + total points + on-chain status pill (Minted / Mintable / Off chain) with a glass tooltip.
- **Sub-credential rows:** each component as an iconed row with its own points + verified / expiry, paginated (dots + arrows), never scrolled. **How the score is computed** is a weighted bar whose segment lengths sum to the total (one accent family, no rainbow, no legend).
- **Action area (bottom-pinned):** one state-driven primary — **Mint** (gold reward when mintable) / **Claim** (unverified) / **View on chain** (minted) / **Verified** (done). Optional **Renew** sits beside the primary on one row. All dev-overridable via callbacks + label props + an `actionState` override.

## Props API

`stamp: StampDetail` (extends `Stamp` with `components: { name, points, verified, expiry?, icon? }[]` and `description?`); `open?`, `size?`, `componentsPerPage?`; callbacks `onClose?`, `onMint?`, `onClaim?`, `onViewOnchain?`, `onRenew?`; overrides `actionState?`, `mintLabel?`, `claimLabel?`, `viewOnchainLabel?`, `verifiedLabel?`, `renewLabel?`, `statusTooltip?`.

## Stories (both themes, under `Redesign/Stamp Detail`)

Verified + minted (View on chain + Renew) · Mintable (gold Mint reward) · Unverified (Claim) · Clean Hands SBT · Paginated components · Interactive (tap a medallion to open its drawer).

## Green

`npx tsc --noEmit`, `yarn build-storybook`, `npx jest test/utils/themes.test.tsx` all pass. No em/en dashes in any copy. Verified via Playwright screenshots in both themes: nothing clipped, no scrollbars (paginated), action bottom-pinned above the shared footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)