### PR TITLE
redesign: SOP lint fixes — tooltip/indicator/state clarity, drawer accordion + fit, real onchain metadata

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import {
   computePosition,
   flip,
@@ -100,23 +101,32 @@ export const Tooltip: React.FC<TooltipProps> = ({ content, placement = "top", ch
         {children}
       </div>
 
-      {/* Portal the tooltip to body to avoid transform/position issues */}
-      {isVisible && (
-        <div
-          ref={tooltipRef}
-          className={`${styles.tooltip} ${className}`}
-          role="tooltip"
-          style={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            width: "max-content",
-          }}
-        >
-          <div className={styles.content}>{content}</div>
-          <div ref={arrowRef} className={styles.arrow} />
-        </div>
-      )}
+      {/* Portal the floating layer to document.body so it escapes any transformed,
+          blurred, or clipped ancestor (the shell chrome, glass surfaces, the
+          drawer). Anchored to the live trigger node via floating-ui, so a
+          position:fixed layer is never trapped in a containing block, never
+          occluded by higher-z chrome, and edge-flips / shifts against the
+          VIEWPORT so it is never clipped (design-sop overlay layering). SSR-safe:
+          only portals once document exists. */}
+      {isVisible &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={tooltipRef}
+            className={`${styles.tooltip} ${className}`}
+            role="tooltip"
+            style={{
+              position: "fixed",
+              top: 0,
+              left: 0,
+              width: "max-content",
+            }}
+          >
+            <div className={styles.content}>{content}</div>
+            <div ref={arrowRef} className={styles.arrow} />
+          </div>,
+          document.body
+        )}
     </>
   );
 };

--- a/src/redesign/PassportShell.module.css
+++ b/src/redesign/PassportShell.module.css
@@ -143,6 +143,73 @@
   outline-offset: 2px;
 }
 
+/* ---- persistent mini score (top-left of the chrome) ---- */
+.miniScore {
+  position: relative;
+  flex: none;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-surface));
+}
+/* Invisible >=40px hit target (a11y §8): 32px + 2x5px = 42px. */
+.miniScore::before {
+  content: "";
+  position: absolute;
+  inset: -5px;
+}
+.miniScore:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+  border-radius: var(--radius-pill-c6dbf459);
+}
+.miniScore:hover .miniScoreArc {
+  filter: brightness(1.08);
+}
+.miniScoreSvg {
+  position: absolute;
+  inset: 0;
+  width: 32px;
+  height: 32px;
+  display: block;
+}
+.miniScoreTrack {
+  fill: none;
+  stroke: rgba(var(--on-surface), 0.14);
+  stroke-width: 3;
+}
+.miniScoreArc {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.miniScore[data-passing="true"] .miniScoreArc {
+  stroke: rgb(var(--accent));
+}
+.miniScore[data-passing="false"] .miniScoreArc {
+  stroke: rgb(var(--warn));
+}
+.miniScoreNum {
+  position: relative;
+  font-size: 12px;
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  color: rgb(var(--on-surface));
+}
+@media (prefers-reduced-motion: reduce) {
+  .miniScoreArc {
+    transition: none;
+  }
+}
+
 .spacer {
   flex: 1;
 }

--- a/src/redesign/PassportShell.module.css
+++ b/src/redesign/PassportShell.module.css
@@ -1,0 +1,740 @@
+/*
+ * PassportShell - the rounded binding. Everything lives INSIDE these bounds.
+ * All color/size/motion comes from the widget's shared tokens (§1); no magic
+ * numbers, no theme-specific literals (§2). No backdrop-filter/transform on any
+ * ancestor of a tooltip trigger, so the portal-style Tooltip (position:fixed)
+ * is never trapped in a containing block and never clips (§4 overlay layering).
+ */
+
+.shell {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-4-c6dbf459);
+  border-radius: var(--widget-radius-c6dbf459);
+  background: rgb(var(--surface));
+  /* No hard line: the shell reads as its own lifted surface via layered shadow +
+   * the wash, not a 1px outline. The edge tokens add a hairline light inner rim
+   * and a soft ambient outer glow so a near-black widget separates from a DARK
+   * host (§no-hard-lines); --shadow-md carries the depth on a light host. */
+  box-shadow:
+    var(--rd-edge-rim),
+    var(--rd-edge-glow),
+    var(--shadow-md-c6dbf459);
+  color: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  /* content + overlays escape; only the decorative .fx is clipped */
+  overflow: visible;
+}
+
+/* Decorative living-material wash: a subtle emerald paper-shader field. Its color
+ * is the integrator-configurable --rd-wash token (defaults to the accent). A
+ * SIBLING layer (not an ancestor of any trigger), clipped to the rounded bounds.
+ * A lightweight animated gradient drift stands in for a full canvas paper-shader.
+ * Legibility first: kept low-alpha and behind all content. */
+.fx {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+  /* Alphas raised so the soft emerald wash actually reads on the brand dark
+   * surface (#101815), while staying subtle on the light (white) surface. */
+  background:
+    radial-gradient(120% 80% at 85% -10%, rgba(var(--rd-wash), 0.24), transparent 60%),
+    radial-gradient(95% 75% at -12% 112%, rgba(var(--rd-wash), 0.16), transparent 55%),
+    radial-gradient(70% 60% at 50% 40%, rgba(var(--rd-wash), 0.07), transparent 70%);
+  background-size: 160% 160%, 170% 170%, 200% 200%;
+  animation: washDrift 18s ease-in-out infinite alternate;
+}
+@keyframes washDrift {
+  0% {
+    background-position: 0% 0%, 100% 100%, 50% 50%;
+  }
+  100% {
+    background-position: 12% 8%, 88% 92%, 46% 54%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fx {
+    animation: none;
+  }
+}
+
+/* ---- size variants: one standard shell height across states (§ structure) ---- */
+/* `full` gives the content region a FIXED height so the default score, account,
+ * and drill-down states share one shell height AND so the window's bottom-pinned
+ * action area lands the primary CTA at the same coordinates in every state. */
+.full .content {
+  /* Tall enough for the busiest state (below-threshold: ring + headline + sub +
+   * to-go + TWO stacked CTAs) with headroom, so nothing clips and the auto gap
+   * has room to push the action area to the bottom in every state. */
+  height: 384px;
+}
+/* mini is a condensed ~half-size card; pill is a single compact row. Both are
+ * fixed-height for the same pin-the-CTA reason. */
+.mini .content {
+  height: 192px;
+}
+.pill,
+.mini {
+  padding: var(--space-3-c6dbf459);
+}
+/* The pill carries NO chrome and NO footer: the whole widget is one short row.
+ * The content region is exactly the ring-height row, vertically centered, with
+ * no top margin (there is no chrome above it to clear). */
+.pill .content {
+  height: 44px;
+  margin-top: 0;
+  justify-content: center;
+}
+
+.shell > *:not(.fx) {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---- chrome row: app-icon · account · ⓘ ---- */
+/* position:relative so the account dropdown anchors to the chrome row, which
+ * spans the shell's content box - letting the menu pin left:0 / right:0 and
+ * stay inside the shell at ANY widget width. */
+.chrome {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+}
+
+/* The chrome row (and the account dropdown it contains) must outrank the score
+ * content below it, or the ring - a later `.shell > *` at the same z-index -  * paints over the open menu. Higher-specificity + later-in-file than the shared
+ * `.shell > *:not(.fx)` rule, so it wins without !important. */
+.shell > .chrome {
+  z-index: 3;
+}
+
+.gl {
+  display: block;
+}
+
+.appIcon {
+  position: relative;
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-lg-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-surface));
+  /* Tonal fill, no hard outline. */
+  background: rgba(var(--on-surface), 0.06);
+  cursor: help;
+}
+/* Invisible ≥40px hit target (a11y §8): 34px + 2×4px = 42px. Visual size unchanged. */
+.appIcon::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+}
+.appIcon:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+/* ---- account selector ---- */
+/* NOT positioned: the menu anchors to .chrome (the content-box-wide row) so it
+ * spans the shell width instead of the narrow trigger. */
+.acctWrap {
+  min-width: 0;
+  margin-right: auto;
+}
+
+.acct {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  margin: 0;
+  padding: var(--space-1-c6dbf459) var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: var(--line-tight-c6dbf459);
+  min-width: 0;
+  cursor: pointer;
+  color: inherit;
+  text-align: left;
+  font-family: inherit;
+}
+.acct:hover {
+  background: rgba(var(--on-surface), 0.05);
+}
+.acct:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 1px;
+}
+
+.acctLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.7);
+  transform: scale(0.82);
+  transform-origin: left center;
+}
+
+.acctWho {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.acctName {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.acctOf {
+  font-weight: var(--weight-regular-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+}
+
+.acctCaret {
+  flex: none;
+  color: rgba(var(--on-surface), 0.6);
+  transition: transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.acctOpen .acctCaret {
+  transform: rotate(180deg);
+}
+
+/* dropdown: TOP z-index, near-opaque backdrop, never clipped and NEVER outside
+ * the shell (§ overlay layering). It spans the shell's content box: pulled left
+ * past the account trigger to the shell content's left edge (the app-icon start
+ * = appIcon width 34px + the chrome gap) and sized to the content width, so its
+ * right edge lands on the content edge instead of overflowing the rounded bound.
+ * Fades (opacity), collapses instantly under reduced-motion below. */
+.menu {
+  position: absolute;
+  box-sizing: border-box;
+  top: calc(100% + var(--space-1-c6dbf459));
+  left: 0;
+  right: 0;
+  z-index: 400;
+  padding: var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  /* Elevated, near-opaque glass: lifts off the shell as a distinct layer in BOTH
+   * themes (darkens slightly on white, lightens slightly on near-black), never
+   * black-on-black. High-alpha surface so the content behind never bleeds
+   * through; blur + shadow carry the separation instead of a hard border. */
+  background:
+    linear-gradient(rgba(var(--on-surface), 0.08), rgba(var(--on-surface), 0.08)),
+    rgba(var(--surface), 0.98);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  backdrop-filter: blur(14px) saturate(1.2);
+  box-shadow:
+    var(--shadow-md-c6dbf459),
+    inset 0 0 0 1px rgba(var(--on-surface), 0.06);
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top left;
+  pointer-events: none;
+  transition:
+    opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.acctOpen .menu {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+/* Small uppercase zone label. */
+.zoneHead {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.6);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+}
+
+/* Zones are separated by SPACE and a faint tonal band, never a hard line. */
+.zoneMid {
+  margin-top: var(--space-1-c6dbf459);
+  padding-top: var(--space-1-c6dbf459);
+}
+.zoneBottom {
+  margin-top: var(--space-1-c6dbf459);
+  padding-top: var(--space-1-c6dbf459);
+}
+
+/* (a) top: the WaaP account behind the passport. */
+.zoneTop {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: rgba(var(--on-surface), 0.05);
+}
+.waapMark {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: var(--radius-md-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-accent));
+  background: linear-gradient(135deg, rgb(var(--accent)), rgba(var(--accent), 0.55));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+.waapMeta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 1px;
+}
+.waapName {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.waapLine {
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.75);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Address line holds the truncating address plus the hover-to-copy control. */
+.waapAddrRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.waapAddr {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  color: rgba(var(--on-surface), 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* ---- hover-to-copy control (account address + linked wallet rows) ---- */
+/* Hidden until the row is hovered or the button is focused (keyboard-reachable),
+ * but always laid out so revealing it never shifts the row. On copy it swaps to
+ * a check + "Copied" and stays visible for the ~1.5s confirmation window. */
+.copyBtn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 6px;
+  border: 0;
+  border-radius: var(--radius-sm-c6dbf459);
+  background: transparent;
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  opacity: 0;
+  transition:
+    opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.zoneTop:hover .copyBtn,
+.walletRow:hover .copyBtn,
+.copyBtn:focus-visible {
+  opacity: 1;
+}
+.copyBtn:hover {
+  background: rgba(var(--accent), 0.12);
+  color: rgb(var(--on-surface));
+}
+.copyBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+/* Confirmed state: stays visible (even without hover) while "Copied" shows. */
+.copyBtnDone,
+.copyBtnDone:hover {
+  opacity: 1;
+  color: rgb(var(--accent));
+  background: rgba(var(--accent), 0.12);
+}
+.copyGlyph {
+  display: inline-flex;
+}
+.copyText {
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copyBtn {
+    transition: none;
+  }
+}
+
+/* (b) middle: linked wallet rows + link-additional CTA. */
+.walletRow {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+}
+.walletIcon {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-sm-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.8);
+  background: rgba(var(--on-surface), 0.06);
+}
+.walletMeta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+.walletName {
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.walletReason {
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.walletKind {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.66);
+}
+
+/* A wallet in cooldown / pending: dimmed row + an amber status pill with a short
+ * plain reason line. It reads as "not usable yet", never a hard failure. */
+.walletRowMuted .walletName {
+  color: rgba(var(--on-surface), 0.72);
+}
+.walletRowMuted .walletIcon {
+  opacity: 0.7;
+}
+.walletStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  padding: 2px 7px;
+  border-radius: var(--radius-pill-c6dbf459);
+  color: rgb(var(--warn));
+  background: rgba(var(--warn), 0.15);
+}
+
+/* Unlink control: hidden until the row is hovered or the button is focused, but
+ * always present in the layout (no shift) and keyboard-reachable. */
+.unlinkBtn {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.walletRow:hover .unlinkBtn,
+.unlinkBtn:focus-visible {
+  opacity: 1;
+}
+.unlinkBtn:hover {
+  background: rgba(var(--danger), 0.14);
+  color: rgb(var(--danger));
+}
+.unlinkBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+
+/* Pagination for >3 linked wallets: dots + arrows, NEVER a scrollbar (§ never
+ * scroll). */
+.walletPager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459) 0;
+}
+.pagerArrow {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.zoneEmpty {
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+}
+.linkWalletBtn {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  margin-top: var(--space-1-c6dbf459);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  background: rgba(var(--accent), 0.12);
+  color: rgb(var(--on-surface));
+  font-family: inherit;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.linkWalletBtn:hover {
+  background: rgba(var(--accent), 0.2);
+}
+.linkWalletBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.linkWalletBtn svg {
+  color: rgb(var(--accent));
+}
+
+/* (c) bottom: switch accounts + sign out. */
+.switchGroup {
+  margin-bottom: var(--space-1-c6dbf459);
+}
+.signOut {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  background: transparent;
+  color: rgba(var(--on-surface), 0.8);
+  font-family: inherit;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.signOut:hover {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+}
+.signOut:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+
+.menuItem {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  text-align: left;
+}
+.menuItem:hover {
+  background: rgba(var(--on-surface), 0.07);
+}
+.menuItem:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.menuItemOn {
+  background: rgba(var(--accent), 0.16);
+}
+.menuItemOn:hover {
+  background: rgba(var(--accent), 0.22);
+}
+
+.menuAvatar {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: var(--radius-md-c6dbf459);
+  background: linear-gradient(135deg, rgb(var(--accent)), rgba(var(--accent), 0.45));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.menuName {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menuKind {
+  margin-left: auto;
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.72);
+}
+
+/* ---- ⓘ help ---- */
+.info {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.72);
+  background: rgba(var(--on-surface), 0.05);
+  cursor: help;
+}
+/* Invisible ≥40px hit target (a11y §8): 22px + 2×9px = 40px. Visual size unchanged. */
+.info::before {
+  content: "";
+  position: absolute;
+  inset: -9px;
+}
+.info:hover {
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.1);
+}
+.info:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- content window ---- */
+.content {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--space-3-c6dbf459);
+}
+
+/* Footer lives in the shared SecuredByFooter component (§ harmonized footer). */
+
+@media (prefers-reduced-motion: reduce) {
+  .menu,
+  .acctCaret {
+    transition: none;
+  }
+}

--- a/src/redesign/PassportShell.module.css
+++ b/src/redesign/PassportShell.module.css
@@ -64,7 +64,19 @@
   }
 }
 
-/* ---- size variants: one standard shell height across states (§ structure) ---- */
+/* ---- size variants: one standard shell WIDTH and HEIGHT across states ------- */
+/* A fixed width per size variant so category switches, pagination, and state
+ * changes never resize the frame (the shell used to shrink-to-fit its content,
+ * so a longer name or a different page jiggled the width). max-width:100% keeps
+ * it responsive: it caps to the host on a narrower surface, but is otherwise
+ * pixel-stable at 300 regardless of what the window renders. */
+.full,
+.mini,
+.pill {
+  width: 300px;
+  max-width: 100%;
+}
+
 /* `full` gives the content region a FIXED height so the default score, account,
  * and drill-down states share one shell height AND so the window's bottom-pinned
  * action area lands the primary CTA at the same coordinates in every state. */

--- a/src/redesign/PassportShell.stories.tsx
+++ b/src/redesign/PassportShell.stories.tsx
@@ -453,3 +453,25 @@ export const SizeComparison: Story = {
     },
   },
 };
+
+export const PersistentScore: Story = {
+  name: "Shell / Persistent score in chrome",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} score={17} threshold={20} onScoreClick={() => undefined}>
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+      <PassportShell account={SAMPLE_ACCOUNT} score={24} threshold={20} onScoreClick={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The compact score lives in the shell chrome, top-left, so it is visible on every window. It reuses the Score window color logic: amber below the threshold (left, 17/20), emerald at or above it (right, 24/20). Tapping it opens the Score window / drilldown. The full big-ring Score window still exists; this is the persistent mini indicator.",
+      },
+    },
+  },
+};

--- a/src/redesign/PassportShell.stories.tsx
+++ b/src/redesign/PassportShell.stories.tsx
@@ -1,0 +1,455 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { PassportShell } from "./PassportShell";
+import { ScoreWindow } from "./ScoreWindow";
+import { Widget } from "../widgets/Widget";
+import { LightTheme } from "../utils/themes";
+import {
+  ThemePair,
+  SAMPLE_ACCOUNT,
+  ACCOUNT_ONE_WALLET,
+  ACCOUNT_THREE_WALLETS,
+  ACCOUNT_SIX_WALLETS,
+  ACCOUNT_COOLDOWN,
+} from "./storyFrame";
+
+/**
+ * PassportShell - the chrome binding: app-icon slot · account menu · ⓘ · the
+ * shared "Secured by human.tech" footer, all INSIDE the rounded bounds. No hard
+ * lines. Rendered in both themes on matching host backgrounds.
+ */
+const meta: Meta<typeof PassportShell> = {
+  title: "Redesign/Shell",
+  component: PassportShell,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof PassportShell>;
+
+/** A stand-in for an integrator's own brand mark, passed via the appIcon prop. */
+const SampleAppIcon = (
+  <span
+    style={{
+      display: "grid",
+      placeItems: "center",
+      width: 20,
+      height: 20,
+      borderRadius: 5,
+      background: "linear-gradient(135deg, #7c3aed, #4f46e5)",
+      color: "#fff",
+      fontWeight: 700,
+      fontSize: 12,
+    }}
+  >
+    A
+  </span>
+);
+
+export const Default: Story = {
+  name: "Shell / Default (no app-icon)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The default: NO app-icon. The slot renders nothing (no placeholder box) and the header leads with the 'Shady.eth's Passport ▾' account selector, then the ⓘ help affordance, all inside the rounded shell. Hover the ⓘ for a glass tooltip (edge-aware, never clipped). Note the soft light edge separating the widget from the host background, clearest on the dark host.",
+      },
+    },
+  },
+};
+
+export const AppIconTooltip: Story = {
+  name: "Shell / With integrator app-icon",
+  render: () => (
+    <ThemePair>
+      <PassportShell
+        account={SAMPLE_ACCOUNT}
+        appIcon={SampleAppIcon}
+        appIconTooltip="Verify with Acme to keep your account in good standing."
+      >
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        // The explanatory sentence lives HERE (dev documentation), never in the
+        // shipped component. It is the app-icon's tooltip only because the
+        // integrator supplied it via appIconTooltip.
+        story:
+          "When the integrator passes appIcon, their own product icon leads the header (here a sample 'Acme' mark). It is their brand, not ours, so the component ships no explanatory tooltip of its own. It renders one only when the integrator also supplies appIconTooltip, shown here with sample integrator copy.",
+      },
+    },
+  },
+};
+
+export const AccountMenuOpen: Story = {
+  name: "Shell / Account menu open (three zones)",
+  render: () => (
+    <ThemePair>
+      <PassportShell
+        account={SAMPLE_ACCOUNT}
+        defaultAccountMenuOpen
+        onLinkWallet={() => undefined}
+        onUnlinkWallet={() => undefined}
+        onSignOut={() => undefined}
+      >
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The account menu in three zones. Top: the WaaP account behind the passport (mark + name + email + address). Middle: linked wallets plus a 'Link additional wallet' CTA. Bottom: switch accounts and sign out. Left-aligned, near-opaque glass, top z-index, contained within the shell.",
+      },
+    },
+  },
+};
+
+export const OneLinkedWallet: Story = {
+  name: "Shell / Wallets: one linked",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_ONE_WALLET} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "A single linked wallet. Hover the row (or tab to it) to reveal the unlink control. No pager." },
+    },
+  },
+};
+
+export const ThreeLinkedWallets: Story = {
+  name: "Shell / Wallets: three linked",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_THREE_WALLETS} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "Three wallets fill one page exactly, so no pager appears. Each row exposes an unlink control on hover / focus." },
+    },
+  },
+};
+
+export const SixLinkedWallets: Story = {
+  name: "Shell / Wallets: six linked (paginated)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_SIX_WALLETS} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "More than three wallets paginate into pages of three with dots and arrows. There is never a scrollbar (SOP never-scroll rule). Arrows and dots are keyboard-reachable.",
+      },
+    },
+  },
+};
+
+export const WalletCooldown: Story = {
+  name: "Shell / Wallets: cooldown + pending",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={ACCOUNT_COOLDOWN} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A wallet in cooldown and one still pending each render a dimmed row with an amber status pill and a short plain reason. Pending wallets are not yet unlinkable; cooldown wallets still expose unlink.",
+      },
+    },
+  },
+};
+
+export const NoAccount: Story = {
+  name: "Shell / Without account selector",
+  render: () => (
+    <ThemePair>
+      <PassportShell>
+        <ScoreWindow state="below" score={12} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Integrator supplies no account identity, so the selector collapses and the chrome stays balanced (app-icon + ⓘ).",
+      },
+    },
+  },
+};
+
+export const HiddenAccountSelector: Story = {
+  name: "Shell / Account selector hidden (accountSelector=false)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} appIcon={SampleAppIcon} accountSelector={false}>
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The accountSelector={false} customization knob hides the account selector from the header even though an account is supplied. The header leads with the integrator's app-icon (or nothing when no app-icon is given), then the ⓘ. Use this when the integrator drives identity in their own chrome.",
+      },
+    },
+  },
+};
+
+export const CopyOnHover: Story = {
+  name: "Shell / Copy address on hover",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} defaultAccountMenuOpen onUnlinkWallet={() => undefined}>
+        <ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Hover (or tab to) the passport account address and any linked wallet row to reveal a small copy control. Clicking copies the FULL address to the clipboard (the rows show a truncated form) and briefly shows a check + 'Copied', reverting after ~1.5s. Keyboard-reachable.",
+      },
+    },
+  },
+};
+
+export const CustomWash: Story = {
+  name: "Shell / Integrator wash color",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT} washRgb="139, 92, 246">
+        <ScoreWindow state="below" score={17} threshold={20} addVerificationsCta={{}} linkIdentityCta={{}} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The paper-shader wash is integrator-configurable via the washRgb prop (an r, g, b triplet). Here a violet wash replaces the default emerald, while the ring / CTA accent stays on the theme.",
+      },
+    },
+  },
+};
+
+export const PillVariant: Story = {
+  name: "Shell / Size variant: pill",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          onContinue={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The compact 'pill' size: one true single row. The score ring stands in for the app-icon at the left (showing the score, e.g. 24), then the account name / short address preview, then a narrow Continue action, all on the same pill-height row. No app-icon, no ⓘ, no 'Verified' word, and no footer. The only tooltip is the score-hover on the ring. Clearly distinct from mini and full.",
+      },
+    },
+  },
+};
+
+export const PillLoading: Story = {
+  name: "Shell / Pill: loading",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow size="pill" state="loading" />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill loading state: a small loader stands in for the ring plus a short label, all on the one pill row, with the compact 'Secured by human.tech' lockup beneath.",
+      },
+    },
+  },
+};
+
+export const PillBelow: Story = {
+  name: "Shell / Pill: below threshold",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="below"
+          score={17}
+          threshold={20}
+          addVerificationsCta={{ onClick: () => undefined }}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill below-threshold state: the small amber ring, a 'N to go' label, and one compact 'Verify' action, kept to a single short row.",
+      },
+    },
+  },
+};
+
+export const PillVerified: Story = {
+  name: "Shell / Pill: verified",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          onContinue={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill verified state: the completed emerald ring, the account preview, and a compact Continue hand-off, all on one row.",
+      },
+    },
+  },
+};
+
+export const PillError: Story = {
+  name: "Shell / Pill: error",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow size="pill" state="error" errorKind="network" onRetry={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The pill error state: a compact danger mark, the short humanized title (never a raw error message), and a compact Retry, all on one row.",
+      },
+    },
+  },
+};
+
+export const PillStatusOnly: Story = {
+  name: "Shell / Pill: verified, no action (showAction=false)",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="pill">
+        <ScoreWindow
+          size="pill"
+          state="verified"
+          score={24}
+          threshold={20}
+          accountPreview={SAMPLE_ACCOUNT.display}
+          showAction={false}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The button on/off option: showAction={false} renders a status-only pill with no action button, just the score ring and the account preview. The integrator drives any hand-off in their own UI.",
+      },
+    },
+  },
+};
+
+export const MiniVariant: Story = {
+  name: "Shell / Size variant: mini",
+  render: () => (
+    <ThemePair>
+      <PassportShell size="mini" account={SAMPLE_ACCOUNT}>
+        <ScoreWindow size="mini" state="verified" score={24} threshold={20} onContinue={() => undefined} />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The 'mini' size: a condensed roughly half-height card with a smaller ring, tighter spacing, and a single action. In the verified state the 'You're verified' line folds INTO the CTA (check + 'You're verified', which continues on tap) to save vertical space: ring + that one button + footer, no standalone verified line. Distinct from the single-row pill and the full card.",
+      },
+    },
+  },
+};
+
+export const SizeComparison: Story = {
+  name: "Shell / All three sizes",
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: 28,
+        flexWrap: "wrap",
+        alignItems: "flex-start",
+        padding: 24,
+        borderRadius: 20,
+        background: "#eef0f4",
+      }}
+    >
+      {(["full", "mini", "pill"] as const).map((s) => (
+        <div key={s} style={{ width: 300 }}>
+          <Widget theme={LightTheme}>
+            <PassportShell size={s} account={s === "pill" ? undefined : SAMPLE_ACCOUNT}>
+              <ScoreWindow
+                size={s}
+                state="verified"
+                score={24}
+                threshold={20}
+                accountPreview={s === "pill" ? SAMPLE_ACCOUNT.display : undefined}
+                onContinue={() => undefined}
+              />
+            </PassportShell>
+          </Widget>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: { story: "full, mini, and pill side by side so the three variants visibly differ in size and layout." },
+    },
+  },
+};

--- a/src/redesign/PassportShell.tsx
+++ b/src/redesign/PassportShell.tsx
@@ -99,6 +99,17 @@ export type PassportShellProps = {
   onUnlinkWallet?: (index: number) => void;
   /** Sign out of the account (bottom zone). */
   onSignOut?: () => void;
+  /**
+   * Persistent humanity score shown as a compact ring + number in the header,
+   * visible on EVERY window (Score, Stamps, Detail). Omit to hide it. It reuses
+   * the Score window's color logic: amber below the threshold, emerald at or
+   * above it. Tapping it fires `onScoreClick` (open the Score window / drilldown).
+   */
+  score?: number;
+  /** Passing threshold for the compact score ring (defaults to 20). */
+  threshold?: number;
+  /** Tap the compact score to open the Score window / drilldown. */
+  onScoreClick?: () => void;
   /** ⓘ help tooltip content. */
   infoTooltip?: React.ReactNode;
   /** Render the account menu open on mount (stories / controlled first-paint). */
@@ -400,11 +411,58 @@ const AccountMenu: React.FC<{
   );
 };
 
+const COMPACT_RING_R = 13;
+const COMPACT_RING_C = 2 * Math.PI * COMPACT_RING_R;
+
 /**
- * PassportShell - the persistent binding around every window. App-icon slot ·
- * account menu · ⓘ help · the shared "Secured by human.tech" footer, all INSIDE
- * the rounded bounds. Structure is space and tone, not hard lines. Presentational:
- * props only, no data hooks, fully self-contained + theme-driven.
+ * The persistent mini score: a small ring + number that lives in the shell chrome
+ * so the humanity score is visible on every window. Amber below the threshold,
+ * emerald at or above it (the same semantic as the full ScoreWindow ring). Tap to
+ * open the Score window / drilldown. Kept to a >=40px hit target for a11y.
+ */
+const CompactScore: React.FC<{ score: number; threshold: number; onClick?: () => void }> = ({
+  score,
+  threshold,
+  onClick,
+}) => {
+  const passing = score >= threshold;
+  const fill = threshold > 0 ? Math.max(0, Math.min(1, score / threshold)) : 0;
+  const rounded = Math.round(score);
+  const label = `Humanity score ${rounded} of ${threshold}. ${
+    passing ? "Above the threshold." : "Below the threshold."
+  } Open your score.`;
+  return (
+    <button
+      type="button"
+      className={styles.miniScore}
+      data-passing={passing ? "true" : "false"}
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+    >
+      <svg className={styles.miniScoreSvg} viewBox="0 0 32 32" aria-hidden="true">
+        <circle className={styles.miniScoreTrack} cx="16" cy="16" r={COMPACT_RING_R} />
+        <circle
+          className={styles.miniScoreArc}
+          cx="16"
+          cy="16"
+          r={COMPACT_RING_R}
+          transform="rotate(-90 16 16)"
+          strokeDasharray={COMPACT_RING_C}
+          strokeDashoffset={COMPACT_RING_C * (1 - fill)}
+        />
+      </svg>
+      <span className={styles.miniScoreNum}>{rounded}</span>
+    </button>
+  );
+};
+
+/**
+ * PassportShell - the persistent binding around every window. Compact score ·
+ * app-icon slot · account menu · ⓘ help · the shared "Secured by human.tech"
+ * footer, all INSIDE the rounded bounds. Structure is space and tone, not hard
+ * lines. Presentational: props only, no data hooks, fully self-contained +
+ * theme-driven.
  */
 export const PassportShell: React.FC<PassportShellProps> = ({
   appIcon,
@@ -416,6 +474,9 @@ export const PassportShell: React.FC<PassportShellProps> = ({
   onLinkWallet,
   onUnlinkWallet,
   onSignOut,
+  score,
+  threshold = 20,
+  onScoreClick,
   infoTooltip = DEFAULT_INFO_TIP,
   defaultAccountMenuOpen,
   washRgb,
@@ -463,6 +524,12 @@ export const PassportShell: React.FC<PassportShellProps> = ({
       <div className={styles.fx} aria-hidden="true" />
 
       <div className={styles.chrome}>
+        {/* Persistent mini score (top-left): visible on every window when a score
+            is supplied. The full Score window still carries the big ring. */}
+        {score !== undefined ? (
+          <CompactScore score={score} threshold={threshold} onClick={onScoreClick} />
+        ) : null}
+
         {/* The app-icon slot only appears when the integrator passes appIcon.
             No default tooltip either: the icon is the integrator's brand, so we
             wrap it only when they supply their own appIconTooltip copy. */}

--- a/src/redesign/PassportShell.tsx
+++ b/src/redesign/PassportShell.tsx
@@ -1,0 +1,505 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./PassportShell.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import {
+  CaretDownIcon,
+  CheckIcon,
+  ClockIcon,
+  CopyIcon,
+  InfoIcon,
+  LogoutIcon,
+  PlusIcon,
+  SwitchIcon,
+  UnlinkIcon,
+  WaaPIcon,
+  WalletIcon,
+} from "./icons";
+import { SecuredByFooter } from "./SecuredByFooter";
+
+export type ShellAccountOption = {
+  /** Display name, e.g. "Shady.eth" or "0x1332…4a9f". */
+  display: string;
+  /** Short kind label, e.g. "ENS" / "Wallet". */
+  kind?: string;
+};
+
+/** Linking status of a wallet on the passport. */
+export type LinkedWalletStatus = "active" | "cooldown" | "pending";
+
+export type LinkedWallet = {
+  /** Display name, e.g. "0x1332…4a9f" or "vault.eth". */
+  display: string;
+  /**
+   * Full address to copy from the hover-to-copy control. When omitted, the copy
+   * affordance falls back to copying `display`. Lets the row show a short /
+   * truncated name while the clipboard still gets the complete address.
+   */
+  address?: string;
+  /** Short kind label, e.g. "Wallet" / "ENS" / "Safe". */
+  kind?: string;
+  /** Linking state. Defaults to "active" when omitted. */
+  status?: LinkedWalletStatus;
+  /**
+   * Short human reason shown for a non-active wallet, e.g. "Cooldown until Aug 3"
+   * or "Linking in progress". Kept plain; no crypto jargon.
+   */
+  cooldownUntil?: string;
+};
+
+export type ShellAccount = {
+  /** The passport account name, e.g. "Shady.eth". */
+  display: string;
+  /** The passport account's kind, e.g. "ENS". */
+  kind?: string;
+  /** The WaaP account's email (the account behind the passport). */
+  email?: string;
+  /** The WaaP account's address. */
+  address?: string;
+  /** Wallets / accounts already linked to this passport. */
+  linkedWallets?: LinkedWallet[];
+  /** Selectable identities for the switch-accounts zone. */
+  accounts?: ShellAccountOption[];
+};
+
+export type ShellSize = "full" | "pill" | "mini";
+
+export type PassportShellProps = {
+  /**
+   * Integrator's product icon (top-left slot). OPTIONAL and OFF by default:
+   * when omitted, the slot renders nothing (no placeholder box) and the header
+   * leads with the account selector. Pass a node to lead the header with the
+   * integrator's own brand mark.
+   */
+  appIcon?: React.ReactNode;
+  /**
+   * Optional integrator-supplied hover tooltip for the app-icon. Defaults to
+   * NONE: the app-icon is the integrator's brand, so we ship no explanatory
+   * copy of our own. When omitted, the icon renders with no tooltip. Only has
+   * an effect when `appIcon` is also supplied.
+   */
+  appIconTooltip?: React.ReactNode;
+  /** The passport identity + account menu. Omit to hide the selector. */
+  account?: ShellAccount;
+  /**
+   * Customization-API knob: show or hide the account selector in the header.
+   * Defaults to `true`. When `false`, the header omits the account selector
+   * entirely (leading with the app-icon if one is supplied, else nothing), even
+   * when `account` is provided. Useful for integrators who drive identity in
+   * their own chrome.
+   */
+  accountSelector?: boolean;
+  /** Index of the active account within `account.accounts`. */
+  activeAccountIndex?: number;
+  /** Called with the selected account index (switch accounts). */
+  onSelectAccount?: (index: number) => void;
+  /** Link an additional wallet to the passport (middle zone CTA). */
+  onLinkWallet?: () => void;
+  /** Unlink a linked wallet. Receives its index within `account.linkedWallets`. */
+  onUnlinkWallet?: (index: number) => void;
+  /** Sign out of the account (bottom zone). */
+  onSignOut?: () => void;
+  /** ⓘ help tooltip content. */
+  infoTooltip?: React.ReactNode;
+  /** Render the account menu open on mount (stories / controlled first-paint). */
+  defaultAccountMenuOpen?: boolean;
+  /**
+   * Paper-shader wash color as an "r, g, b" triplet, integrator-configurable.
+   * Defaults to the accent (emerald). Sets --rd-wash on the shell.
+   */
+  washRgb?: string;
+  /**
+   * Size variant. `full` (default) is the crafted card; `mini` is a condensed
+   * ~half-size card; `pill` is a compact single-row pill.
+   */
+  size?: ShellSize;
+  /** The window content (Score window, drill-down, …). */
+  children: React.ReactNode;
+  className?: string;
+};
+
+const DEFAULT_INFO_TIP =
+  "Your humanity score, proven with zero knowledge. Private by default. Nothing personal is revealed.";
+
+/** How many linked wallets show per page before the menu paginates (never scrolls). */
+const WALLETS_PER_PAGE = 3;
+
+const STATUS_LABEL: Record<LinkedWalletStatus, string> = {
+  active: "",
+  cooldown: "Cooldown",
+  pending: "Pending",
+};
+
+/**
+ * Hover-to-copy affordance for a wallet / address row. A small copy icon that
+ * stays hidden until the row is hovered or the button itself is focused (so it
+ * is keyboard-reachable). Clicking copies the full value to the clipboard and
+ * briefly swaps to a check + "Copied", reverting after ~1.5s. Presentational and
+ * self-contained; uses navigator.clipboard.writeText.
+ */
+const COPIED_MS = 1500;
+
+const CopyButton: React.FC<{ value: string; label: string }> = ({ value, label }) => {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+  }, []);
+
+  const copy = useCallback(() => {
+    const done = () => {
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), COPIED_MS);
+    };
+    try {
+      const clip = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+      if (clip?.writeText) {
+        clip.writeText(value).then(done, done);
+      } else {
+        done();
+      }
+    } catch {
+      // Clipboard may be blocked (insecure context, permissions); still confirm.
+      done();
+    }
+  }, [value]);
+
+  return (
+    <button
+      type="button"
+      className={`${styles.copyBtn} ${copied ? styles.copyBtnDone : ""}`}
+      onClick={copy}
+      aria-label={copied ? "Copied" : label}
+      title={copied ? "Copied" : label}
+    >
+      <span className={styles.copyGlyph} aria-hidden="true">
+        {copied ? <CheckIcon size={13} strokeWidth={2.2} /> : <CopyIcon size={13} strokeWidth={1.7} />}
+      </span>
+      {copied ? <span className={styles.copyText}>Copied</span> : null}
+    </button>
+  );
+};
+
+const LinkedWalletRow: React.FC<{
+  wallet: LinkedWallet;
+  index: number;
+  onUnlink?: (index: number) => void;
+}> = ({ wallet, index, onUnlink }) => {
+  const status = wallet.status ?? "active";
+  const muted = status !== "active";
+  // Pending links are still settling, so unlink is not offered yet.
+  const canUnlink = Boolean(onUnlink) && status !== "pending";
+
+  return (
+    <div className={`${styles.walletRow} ${muted ? styles.walletRowMuted : ""}`}>
+      <span className={styles.walletIcon} aria-hidden="true">
+        <WalletIcon size={15} strokeWidth={1.8} />
+      </span>
+      <span className={styles.walletMeta}>
+        <span className={styles.walletName}>{wallet.display}</span>
+        {muted && wallet.cooldownUntil ? (
+          <span className={styles.walletReason}>{wallet.cooldownUntil}</span>
+        ) : null}
+      </span>
+      {muted ? (
+        <span className={styles.walletStatus} aria-label={STATUS_LABEL[status]}>
+          <ClockIcon size={11} strokeWidth={1.9} />
+          {STATUS_LABEL[status]}
+        </span>
+      ) : wallet.kind ? (
+        <span className={styles.walletKind}>{wallet.kind}</span>
+      ) : null}
+      <CopyButton value={wallet.address ?? wallet.display} label={`Copy ${wallet.display}`} />
+      {canUnlink ? (
+        <button
+          type="button"
+          className={styles.unlinkBtn}
+          onClick={() => onUnlink?.(index)}
+          aria-label={`Unlink ${wallet.display}`}
+          title={`Unlink ${wallet.display}`}
+        >
+          <UnlinkIcon size={14} strokeWidth={1.8} />
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+const AccountMenu: React.FC<{
+  account: ShellAccount;
+  activeIndex: number;
+  onSelect?: (index: number) => void;
+  onLinkWallet?: () => void;
+  onUnlinkWallet?: (index: number) => void;
+  onSignOut?: () => void;
+  defaultOpen?: boolean;
+}> = ({ account, activeIndex, onSelect, onLinkWallet, onUnlinkWallet, onSignOut, defaultOpen }) => {
+  const [open, setOpen] = useState(Boolean(defaultOpen));
+  const [walletPage, setWalletPage] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const switchOptions: ShellAccountOption[] = useMemo(
+    () =>
+      account.accounts && account.accounts.length
+        ? account.accounts
+        : [{ display: account.display, kind: account.kind }],
+    [account]
+  );
+  const linkedWallets = account.linkedWallets ?? [];
+  const pageCount = Math.max(1, Math.ceil(linkedWallets.length / WALLETS_PER_PAGE));
+  // Clamp in case the active page falls off the end (e.g. after an unlink).
+  const page = Math.min(walletPage, pageCount - 1);
+  const pageStart = page * WALLETS_PER_PAGE;
+  const pageWallets = linkedWallets.slice(pageStart, pageStart + WALLETS_PER_PAGE);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const select = (index: number) => {
+    onSelect?.(index);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={wrapRef} className={`${styles.acctWrap} ${open ? styles.acctOpen : ""}`}>
+      <button
+        type="button"
+        className={styles.acct}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.acctLabel}>Signed in</span>
+        <span className={styles.acctWho}>
+          <span className={styles.acctName}>{account.display}</span>
+          <span className={styles.acctOf}>&rsquo;s Passport</span>
+          <CaretDownIcon className={styles.acctCaret} size={13} />
+        </span>
+      </button>
+
+      <div className={styles.menu} role="menu" aria-label="Account">
+        {/* (a) top: the passport account = the WaaP account behind it */}
+        <div className={styles.zoneTop}>
+          <span className={styles.waapMark} aria-hidden="true">
+            <WaaPIcon size={20} />
+          </span>
+          <span className={styles.waapMeta}>
+            <span className={styles.waapName}>{account.display}</span>
+            {account.email ? <span className={styles.waapLine}>{account.email}</span> : null}
+            {account.address ? (
+              <span className={styles.waapAddrRow}>
+                <span className={styles.waapAddr}>{account.address}</span>
+                <CopyButton value={account.address} label="Copy address" />
+              </span>
+            ) : null}
+          </span>
+        </div>
+
+        {/* (b) middle: linked wallets (paginated, never scrolled) + link CTA */}
+        <div className={styles.zoneMid}>
+          <div className={styles.zoneHead}>Linked wallets</div>
+          {linkedWallets.length ? (
+            <>
+              {pageWallets.map((w, i) => (
+                <LinkedWalletRow
+                  key={`${w.display}-${pageStart + i}`}
+                  wallet={w}
+                  index={pageStart + i}
+                  onUnlink={onUnlinkWallet}
+                />
+              ))}
+              {pageCount > 1 ? (
+                <div className={styles.walletPager} role="group" aria-label="Linked wallet pages">
+                  <button
+                    type="button"
+                    className={styles.pagerArrow}
+                    onClick={() => setWalletPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    aria-label="Previous wallets"
+                  >
+                    <CaretDownIcon className={styles.pagerPrev} size={13} />
+                  </button>
+                  <span className={styles.pagerDots}>
+                    {Array.from({ length: pageCount }).map((_, i) => (
+                      <button
+                        type="button"
+                        key={i}
+                        className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+                        onClick={() => setWalletPage(i)}
+                        aria-label={`Wallet page ${i + 1}`}
+                        aria-current={i === page ? "true" : undefined}
+                      />
+                    ))}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.pagerArrow}
+                    onClick={() => setWalletPage(Math.min(pageCount - 1, page + 1))}
+                    disabled={page === pageCount - 1}
+                    aria-label="More wallets"
+                  >
+                    <CaretDownIcon className={styles.pagerNext} size={13} />
+                  </button>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className={styles.zoneEmpty}>No wallets linked yet.</div>
+          )}
+          <button type="button" className={styles.linkWalletBtn} onClick={onLinkWallet}>
+            <PlusIcon size={15} strokeWidth={2} />
+            Link additional wallet
+          </button>
+        </div>
+
+        {/* (c) bottom: switch accounts + sign out */}
+        <div className={styles.zoneBottom}>
+          {switchOptions.length > 1 ? (
+            <div className={styles.switchGroup} role="group" aria-label="Switch accounts">
+              <div className={styles.zoneHead}>
+                <SwitchIcon size={13} strokeWidth={1.8} />
+                Switch accounts
+              </div>
+              {switchOptions.map((opt, i) => (
+                <button
+                  type="button"
+                  key={`${opt.display}-${i}`}
+                  role="menuitem"
+                  className={`${styles.menuItem} ${i === activeIndex ? styles.menuItemOn : ""}`}
+                  onClick={() => select(i)}
+                >
+                  <span className={styles.menuAvatar} aria-hidden="true" />
+                  <span className={styles.menuName}>{opt.display}</span>
+                  {opt.kind ? <span className={styles.menuKind}>{opt.kind}</span> : null}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <button type="button" className={styles.signOut} onClick={onSignOut}>
+            <LogoutIcon size={15} strokeWidth={1.8} />
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * PassportShell - the persistent binding around every window. App-icon slot ·
+ * account menu · ⓘ help · the shared "Secured by human.tech" footer, all INSIDE
+ * the rounded bounds. Structure is space and tone, not hard lines. Presentational:
+ * props only, no data hooks, fully self-contained + theme-driven.
+ */
+export const PassportShell: React.FC<PassportShellProps> = ({
+  appIcon,
+  appIconTooltip,
+  account,
+  accountSelector = true,
+  activeAccountIndex = 0,
+  onSelectAccount,
+  onLinkWallet,
+  onUnlinkWallet,
+  onSignOut,
+  infoTooltip = DEFAULT_INFO_TIP,
+  defaultAccountMenuOpen,
+  washRgb,
+  size = "full",
+  children,
+  className = "",
+}) => {
+  const handleSelect = useCallback((i: number) => onSelectAccount?.(i), [onSelectAccount]);
+
+  // App-icon slot is OFF by default: only render it when the integrator supplies
+  // their own mark. When absent, the header simply leads with the account.
+  const appIconEl = appIcon ? (
+    <span className={styles.appIcon} tabIndex={appIconTooltip ? 0 : undefined} role="img" aria-label="App icon">
+      {appIcon}
+    </span>
+  ) : null;
+
+  // Whether the account selector actually shows: gated by the accountSelector
+  // knob AND by an account being supplied.
+  const showAccount = accountSelector && Boolean(account);
+
+  // The pill is a true single row: the score ring stands in for the app-icon,
+  // the account preview and the one action live in the window itself. It carries
+  // no header chrome (no app-icon, no account menu, no ⓘ), but it DOES keep the
+  // shared "Secured by human.tech" lockup in a compact form beneath the row so
+  // the mark is never dropped. (See PassportShell.stories / item 1.)
+  if (size === "pill") {
+    return (
+      <div
+        className={`${styles.shell} ${styles.pill} ${className}`}
+        style={washRgb ? ({ "--rd-wash": washRgb } as React.CSSProperties) : undefined}
+      >
+        <div className={styles.fx} aria-hidden="true" />
+        <div className={styles.content}>{children}</div>
+        <SecuredByFooter compact />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${styles.shell} ${styles[size]} ${className}`}
+      style={washRgb ? ({ "--rd-wash": washRgb } as React.CSSProperties) : undefined}
+    >
+      <div className={styles.fx} aria-hidden="true" />
+
+      <div className={styles.chrome}>
+        {/* The app-icon slot only appears when the integrator passes appIcon.
+            No default tooltip either: the icon is the integrator's brand, so we
+            wrap it only when they supply their own appIconTooltip copy. */}
+        {appIconEl ? (
+          appIconTooltip ? (
+            <Tooltip content={appIconTooltip} placement="bottom-start" className={glass.tip}>
+              {appIconEl}
+            </Tooltip>
+          ) : (
+            appIconEl
+          )
+        ) : null}
+
+        {showAccount && account ? (
+          <AccountMenu
+            account={account}
+            activeIndex={activeAccountIndex}
+            onSelect={handleSelect}
+            onLinkWallet={onLinkWallet}
+            onUnlinkWallet={onUnlinkWallet}
+            onSignOut={onSignOut}
+            defaultOpen={defaultAccountMenuOpen}
+          />
+        ) : (
+          <span className={styles.spacer} />
+        )}
+
+        <Tooltip content={infoTooltip} placement="bottom-end" className={glass.tip}>
+          <span className={styles.info} tabIndex={0} role="button" aria-label="About your score">
+            <InfoIcon className={styles.gl} size={13} />
+          </span>
+        </Tooltip>
+      </div>
+
+      <div className={styles.content}>{children}</div>
+
+      <SecuredByFooter />
+    </div>
+  );
+};

--- a/src/redesign/ScoreDrilldown.module.css
+++ b/src/redesign/ScoreDrilldown.module.css
@@ -1,0 +1,171 @@
+/*
+ * ScoreDrilldown - the single ring resolves into disconnected arcs whose LENGTH
+ * encodes each stamp's contribution (uniform stroke-width), points ON each arc,
+ * names close to their arc, palette derived from the accent hue only. No legend,
+ * no "sums to total" caption (SOP §4). Everything scales inside one viewBox so
+ * nothing clips.
+ */
+
+.drilldown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1-c6dbf459);
+  width: 100%;
+}
+
+.back {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  align-self: flex-start;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 4px;
+  margin-bottom: var(--space-1-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  cursor: pointer;
+  color: rgba(var(--on-surface), 0.72);
+  font-family: var(--font-family-body-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+}
+/* Invisible ≥40px hit target (a11y §8): ~18px tall + 2×11px = 40px. Visual size unchanged. */
+.back::before {
+  content: "";
+  position: absolute;
+  inset: -11px;
+}
+.back:hover {
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.06);
+}
+.back:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 1px;
+}
+
+.arcSvg {
+  width: 100%;
+  height: auto;
+  display: block;
+  margin-top: var(--space-1-c6dbf459);
+  overflow: visible;
+}
+
+/* Each segment is tappable: fires onSelectStamp (stamp-detail is a later slice).
+ * No hard outline; the whole group lifts slightly on hover / focus. */
+.segment {
+  cursor: pointer;
+  transition: opacity var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+  outline: none;
+}
+.segment:hover {
+  opacity: 0.82;
+}
+.segment:focus-visible .arc {
+  stroke-width: 19;
+}
+.segment:focus-visible .arcPt {
+  font-size: 15px;
+}
+
+.track {
+  fill: none;
+  stroke: rgba(var(--on-surface), 0.1);
+  stroke-width: 16;
+}
+
+.arc {
+  transition: stroke-dashoffset var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459);
+}
+
+/* the point rides ON its band - white with a dark halo so it reads over any
+ * mid-tone tint, in both themes (paint-order draws the halo behind the fill) */
+.arcPt {
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-size: 13px;
+  fill: #fff;
+  paint-order: stroke;
+  stroke: rgba(0, 0, 0, 0.55);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+  font-variant-numeric: tabular-nums;
+}
+
+/* the name sits just outside its band - theme text color for guaranteed
+ * contrast (association is by proximity, not by a color legend) */
+.arcLabel {
+  font-family: var(--font-family-body-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  fill: rgb(var(--on-surface));
+}
+
+.total {
+  fill: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-size: 38px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* "See all stamps" CTA: tonal (no hard line), full width, inside the shell. */
+.seeAll {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 42px;
+  margin-top: var(--space-3-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  transition: background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.seeAll:hover {
+  background: rgba(var(--on-surface), 0.12);
+}
+.seeAll:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.resolveIn {
+  animation: resolveIn 0.6s var(--ease-standard-c6dbf459) both;
+  transform-origin: 180px 120px;
+}
+@keyframes resolveIn {
+  from {
+    opacity: 0;
+    transform: scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arc,
+  .resolveIn {
+    transition: none;
+    animation: none;
+  }
+}

--- a/src/redesign/ScoreDrilldown.stories.tsx
+++ b/src/redesign/ScoreDrilldown.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ScoreDrilldown } from "./ScoreDrilldown";
+import { PassportShell } from "./PassportShell";
+import { ScoreHome } from "./ScoreHome";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_STAMPS } from "./storyFrame";
+
+/**
+ * ScoreDrilldown - arc LENGTH proportional to contribution, uniform stroke,
+ * points ON each arc, names close by, palette derived from the accent hue only.
+ * No legend, no header, no "sums to total" caption. Both themes.
+ */
+const meta: Meta<typeof ScoreDrilldown> = {
+  title: "Redesign/Score Drilldown",
+  component: ScoreDrilldown,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof ScoreDrilldown>;
+
+export const Breakdown: Story = {
+  name: "Drilldown / Breakdown",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreDrilldown
+          stamps={SAMPLE_STAMPS}
+          total={24}
+          onBack={() => undefined}
+          onSelectStamp={() => undefined}
+          onSeeAllStamps={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The single ring resolved into disconnected component arcs, with no header so the breakdown fills the window. Arc length grows with points; stroke-width is uniform; each arc carries its own points with the stamp name just outside. Tapping a segment fires onSelectStamp. A 'See all stamps' CTA sits below.",
+      },
+    },
+  },
+};
+
+export const ScoreToDrilldown: Story = {
+  name: "Drilldown / Tap the score to open",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <ScoreHome
+          state="verified"
+          score={24}
+          threshold={20}
+          stamps={SAMPLE_STAMPS}
+          onContinue={() => undefined}
+          onSelectStamp={() => undefined}
+          onSeeAllStamps={() => undefined}
+        />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tap the score (ring or the inline verified check) to flip into the drill-down; 'Back to score' returns. Verified state shown; the same tap works below the threshold.",
+      },
+    },
+  },
+};

--- a/src/redesign/ScoreDrilldown.tsx
+++ b/src/redesign/ScoreDrilldown.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo, useRef } from "react";
+import styles from "./ScoreDrilldown.module.css";
+import { ArrowLeftIcon, SparkIcon } from "./icons";
+import { deriveTints } from "./deriveTints";
+import { useAccentRgb, useCountUp, useReducedMotion } from "./hooks";
+
+export type StampContribution = {
+  /** Stable id passed back through onSelectStamp. Falls back to `label`. */
+  id?: string;
+  /** Short stamp label, e.g. "Government ID". */
+  label: string;
+  /** Points this stamp contributes to the total. */
+  points: number;
+};
+
+export type ScoreDrilldownProps = {
+  stamps: StampContribution[];
+  /** Total shown in the ring center. Defaults to the sum of contributions. */
+  total?: number;
+  /** Override the accent triplet ("r, g, b"). Defaults to the resolved --accent. */
+  accentRgb?: string;
+  /** Return to the Score window. */
+  onBack?: () => void;
+  /** Fired when a breakdown segment is tapped (stamp-detail is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /** Fired by the "See all stamps" CTA. */
+  onSeeAllStamps?: () => void;
+};
+
+// Ring geometry lives inside a generous viewBox that scales down to the widget
+// width, so labels are always INSIDE the frame and nothing clips. The breakdown
+// is the whole window now (no header), so the ring is larger.
+const CX = 180;
+const CY = 118;
+const R = 78;
+const SW = 16; // uniform stroke-width on EVERY arc: contribution shows in LENGTH only
+const GAP = 8;
+const C = 2 * Math.PI * R;
+
+type Segment = {
+  id: string;
+  label: string;
+  points: number;
+  color: string;
+  dash: string;
+  offset: number;
+  ptX: number;
+  ptY: number;
+  labelX: number;
+  labelY: number;
+  labelAnchor: "start" | "end" | "middle";
+};
+
+export const ScoreDrilldown: React.FC<ScoreDrilldownProps> = ({
+  stamps,
+  total,
+  accentRgb,
+  onBack,
+  onSelectStamp,
+  onSeeAllStamps,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const accent = useAccentRgb(rootRef, accentRgb);
+
+  const sum = total ?? stamps.reduce((a, s) => a + s.points, 0);
+  const counted = useCountUp(sum, 900, reduced);
+
+  const segments = useMemo<Segment[]>(() => {
+    const denom = stamps.reduce((a, s) => a + s.points, 0) || 1;
+    const ranked = stamps.slice().sort((a, b) => b.points - a.points);
+    const tints = deriveTints(accent, stamps.length);
+    let pos = 0;
+    return stamps.map((s) => {
+      const rank = ranked.indexOf(s);
+      const frac = s.points / denom;
+      const arcLen = frac * C;
+      const draw = Math.max(6, arcLen - GAP);
+      const midAngle = ((pos + arcLen / 2) / C) * 2 * Math.PI - Math.PI / 2;
+      const ux = Math.cos(midAngle);
+      const uy = Math.sin(midAngle);
+      const lr = R + SW / 2 + 12;
+      const seg: Segment = {
+        id: s.id ?? s.label,
+        label: s.label,
+        points: s.points,
+        color: tints[Math.max(0, rank)],
+        dash: `${draw.toFixed(2)} ${(C - draw).toFixed(2)}`,
+        offset: -(pos + GAP / 2),
+        ptX: CX + ux * R,
+        ptY: CY + uy * R,
+        labelX: CX + ux * lr,
+        labelY: CY + uy * lr,
+        labelAnchor: ux >= 0.15 ? "start" : ux <= -0.15 ? "end" : "middle",
+      };
+      pos += arcLen;
+      return seg;
+    });
+  }, [stamps, accent]);
+
+  return (
+    <div ref={rootRef} className={styles.drilldown}>
+      <div className={styles.head}>
+        {onBack ? (
+          <button type="button" className={styles.back} onClick={onBack}>
+            <ArrowLeftIcon size={13} />
+            Back to score
+          </button>
+        ) : (
+          <span />
+        )}
+      </div>
+
+      <svg className={styles.arcSvg} viewBox="0 0 360 236" role="img" aria-label={`Score breakdown, total ${sum}`}>
+        {/* faint track the arcs sit on */}
+        <circle className={styles.track} cx={CX} cy={CY} r={R} />
+
+        <g className={reduced ? "" : styles.resolveIn}>
+          {segments.map((seg, i) => (
+            <g
+              key={`${seg.id}-${i}`}
+              className={onSelectStamp ? styles.segment : undefined}
+              role={onSelectStamp ? "button" : undefined}
+              tabIndex={onSelectStamp ? 0 : undefined}
+              aria-label={onSelectStamp ? `${seg.label}, ${seg.points} points. Open stamp.` : undefined}
+              onClick={onSelectStamp ? () => onSelectStamp(seg.id) : undefined}
+              onKeyDown={
+                onSelectStamp
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSelectStamp(seg.id);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <circle
+                className={styles.arc}
+                cx={CX}
+                cy={CY}
+                r={R}
+                fill="none"
+                stroke={seg.color}
+                strokeWidth={SW}
+                strokeLinecap="round"
+                transform={`rotate(-90 ${CX} ${CY})`}
+                strokeDasharray={seg.dash}
+                strokeDashoffset={seg.offset}
+              />
+              <text
+                className={styles.arcPt}
+                x={seg.ptX.toFixed(1)}
+                y={seg.ptY.toFixed(1)}
+                textAnchor="middle"
+                dominantBaseline="central"
+              >
+                {seg.points}
+              </text>
+              <text
+                className={styles.arcLabel}
+                x={seg.labelX.toFixed(1)}
+                y={seg.labelY.toFixed(1)}
+                textAnchor={seg.labelAnchor}
+                dominantBaseline="middle"
+              >
+                {seg.label}
+              </text>
+            </g>
+          ))}
+        </g>
+
+        <text className={styles.total} x={CX} y={CY} textAnchor="middle" dominantBaseline="central">
+          {Math.round(counted)}
+        </text>
+      </svg>
+
+      <button type="button" className={styles.seeAll} onClick={onSeeAllStamps}>
+        <SparkIcon size={15} strokeWidth={1.9} />
+        See all stamps
+      </button>
+    </div>
+  );
+};

--- a/src/redesign/ScoreHome.tsx
+++ b/src/redesign/ScoreHome.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import { ScoreWindow, ScoreWindowProps } from "./ScoreWindow";
+import { ScoreDrilldown, StampContribution } from "./ScoreDrilldown";
+
+export type ScoreHomeProps = Omit<ScoreWindowProps, "onDrilldown"> & {
+  /** Contribution breakdown shown when the score is tapped. */
+  stamps: StampContribution[];
+  /** Start on the drill-down (stories / deep-link). */
+  defaultView?: "score" | "drilldown";
+  /** Fired when a breakdown segment is tapped (stamp-detail is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /** Fired by the "See all stamps" CTA in the drill-down. */
+  onSeeAllStamps?: () => void;
+};
+
+/**
+ * ScoreHome - thin presentational connector that toggles between the Score
+ * window and its drill-down when the score is tapped. Holds only local view
+ * state (no data hooks), so it stays fully storybookable.
+ */
+export const ScoreHome: React.FC<ScoreHomeProps> = ({
+  stamps,
+  defaultView = "score",
+  onSelectStamp,
+  onSeeAllStamps,
+  ...scoreProps
+}) => {
+  const [view, setView] = useState<"score" | "drilldown">(defaultView);
+
+  if (view === "drilldown") {
+    return (
+      <ScoreDrilldown
+        stamps={stamps}
+        total={scoreProps.score}
+        onBack={() => setView("score")}
+        onSelectStamp={onSelectStamp}
+        onSeeAllStamps={onSeeAllStamps}
+      />
+    );
+  }
+
+  return <ScoreWindow {...scoreProps} onDrilldown={() => setView("drilldown")} />;
+};

--- a/src/redesign/ScoreWindow.module.css
+++ b/src/redesign/ScoreWindow.module.css
@@ -1,0 +1,468 @@
+/*
+ * ScoreWindow - the home / spine. True SVG ring (emerald at/above threshold,
+ * amber below), score is the tap target, cryptex-spirit loader, inline verified
+ * reward. Tokens only (§1); legible in both themes (§2/§8);
+ * all motion degrades under reduced-motion (§4).
+ *
+ * Local display sizes: the big score digit is intentionally larger than the
+ * type scale's ceiling (xl = 20). Declared here as scoped tokens rather than
+ * bare px so they remain single-sourced and re-themable within the redesign.
+ */
+
+.window {
+  --rd-score-digit: 40px;
+  --rd-loader-mark: rgba(var(--accent), 0.9);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  text-align: center;
+  /* Fill the fixed-height content region so the action area can bottom-anchor
+   * (§ structure): the primary CTA lands at the same coordinates in every
+   * state. The score / message area flexes; the buttons do not move. */
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- ring ---- */
+.ringWrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  margin: var(--space-2-c6dbf459) 0 var(--space-1-c6dbf459);
+}
+
+.ringSvg {
+  width: 150px;
+  height: 150px;
+  display: block;
+}
+
+.ringTrack {
+  fill: none;
+  stroke: rgba(var(--on-surface), 0.13);
+  stroke-width: 9;
+}
+
+.ringProgress {
+  fill: none;
+  stroke-width: 9;
+  stroke-linecap: round;
+  transition:
+    stroke-dashoffset var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459),
+    stroke var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Emerald only at or above the threshold. */
+.ringPass {
+  stroke: rgb(var(--accent));
+}
+/* Warm amber below the threshold: "almost there, not yet passing". */
+.ringWarn {
+  stroke: rgb(var(--warn));
+}
+
+/* The whole score (ring + number) is the hover / tap target. Bare button:
+ * no background, no border (no hard lines), just a pointer + focus ring. */
+.ringButton {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  display: block;
+  cursor: pointer;
+  color: inherit;
+  border-radius: var(--radius-pill-c6dbf459);
+}
+.ringButton:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 4px;
+}
+
+.ringNum {
+  position: absolute;
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  color: rgb(var(--on-surface));
+  font-variant-numeric: tabular-nums;
+}
+
+.scoreWrap {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.count {
+  font-size: var(--rd-score-digit);
+  font-weight: var(--weight-bold-c6dbf459);
+  letter-spacing: -0.035em;
+  line-height: var(--line-tight-c6dbf459);
+  font-variant-numeric: tabular-nums;
+}
+
+.outOf {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.7);
+  margin-left: 3px;
+}
+
+/* ---- verified: inline "check + You're verified", animated in together ---- */
+.verifiedLine {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  margin: var(--space-3-c6dbf459) 0 0;
+  animation: verifiedIn 0.5s var(--ease-standard-c6dbf459) 0.35s both;
+}
+.verifiedLineStatic {
+  animation: none;
+}
+@keyframes verifiedIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The green seal / check, now inline with the headline and tappable. */
+.inlineSeal {
+  appearance: none;
+  border: 0;
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  color: rgb(var(--on-accent));
+  background: radial-gradient(circle at 35% 28%, rgba(255, 255, 255, 0.9), rgb(var(--accent)) 80%);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition: filter var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Invisible >=40px hit target (a11y §8): 24px + 2×8px = 40px. */
+.inlineSeal::before {
+  content: "";
+  position: absolute;
+  inset: -8px;
+}
+.inlineSeal:hover {
+  filter: brightness(1.06);
+}
+.inlineSeal:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+.verifiedText {
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-lg-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+
+.ringGlow {
+  position: absolute;
+  width: 150px;
+  height: 150px;
+  border-radius: var(--radius-pill-c6dbf459);
+  pointer-events: none;
+  opacity: 0;
+}
+.celebrate .ringGlow {
+  animation: glowPulse 1.6s ease-out 0.1s both;
+}
+@keyframes glowPulse {
+  0% {
+    opacity: 0;
+    box-shadow: 0 0 0 0 rgba(var(--accent), 0.5);
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    box-shadow: 0 0 0 24px rgba(var(--accent), 0);
+  }
+}
+
+/* Interim loading spinner (indeterminate emerald arc). To be replaced by the
+ * shared Cryptex loader from @holonym-foundation/ui once it is an installable
+ * dependency. Its source is NOT vendored into this public repo. */
+.spin {
+  animation: rdSpin 1s linear infinite;
+  transform-origin: center;
+}
+@keyframes rdSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
+  }
+}
+
+/* ---- text ---- */
+.headline {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-lg-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  margin: var(--space-2-c6dbf459) 0 0;
+  text-wrap: balance;
+}
+
+.sub {
+  color: rgba(var(--on-surface), 0.72);
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  margin: var(--space-1-c6dbf459) 0 0;
+}
+.sub b {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+
+/* ---- to-go progress framing (below threshold) ---- */
+.toGo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+  margin: var(--space-3-c6dbf459) 0 0;
+  padding: var(--space-2-c6dbf459) var(--space-3-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  background: rgba(var(--on-surface), 0.05);
+  box-sizing: border-box;
+}
+.toGoBar {
+  flex: 1;
+  height: 5px;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.13);
+  overflow: hidden;
+}
+.toGoBar i {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-pill-c6dbf459);
+  /* Below the threshold, so the progress fill is amber to match the ring. */
+  background: rgb(var(--warn));
+  transition: width var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.toGoLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  white-space: nowrap;
+}
+
+/* ---- error ---- */
+.errorBadge {
+  width: 56px;
+  height: 56px;
+  margin: var(--space-4-c6dbf459) 0 var(--space-3-c6dbf459);
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--danger));
+  background: rgba(var(--danger), 0.12);
+}
+
+/* ---- CTAs ---- */
+/* Below-threshold action area holds the two configurable CTAs, stacked.
+ * margin-top:auto pins the whole action area to the bottom of the window so the
+ * primary CTA sits at a fixed y across states. */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+  margin-top: auto;
+}
+
+/* ONE shared button metric. Every action button - primary, secondary, the
+ * verified Continue, the error retry - is full width with identical height and
+ * padding. Only the color differs (emerald primary vs tonal secondary). A
+ * standalone .cta (verified / error) bottom-anchors via margin-top:auto. */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  margin-top: auto;
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Buttons inside the stacked action area own their spacing via the flex gap. */
+.actions .cta {
+  margin-top: 0;
+}
+/* The label never wraps, so both CTAs keep the identical single-row box. */
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* Secondary CTA (link wallet): tonal, no hard line. Reads as a quieter step
+ * than the emerald primary, legible in both themes via on-surface tint. */
+.ctaSecondary {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  box-shadow: none;
+}
+.ctaSecondary:hover {
+  filter: none;
+  background: rgba(var(--on-surface), 0.12);
+}
+
+.ctaIcon {
+  display: inline-flex;
+}
+
+/* ---- size variants (§ structure): mini = condensed ~half card, pill = one
+ * compact horizontal row. full is the default layout above. ---- */
+
+/* mini: smaller ring + digit, tighter spacing, primary action only. */
+.miniWin {
+  --rd-score-digit: 26px;
+}
+.miniWin .ringWrap {
+  margin: 0 0 var(--space-1-c6dbf459);
+}
+.miniWin .ringSvg {
+  width: 100px;
+  height: 100px;
+}
+.miniWin .headline {
+  font-size: var(--font-size-md-c6dbf459);
+  margin-top: var(--space-1-c6dbf459);
+}
+.miniWin .verifiedText {
+  font-size: var(--font-size-md-c6dbf459);
+}
+.miniWin .verifiedLine {
+  margin-top: var(--space-2-c6dbf459);
+}
+
+/* pill: a single horizontal row - compact score + label + one action. */
+.pillWin {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  text-align: left;
+  gap: var(--space-2-c6dbf459);
+  --rd-score-digit: 15px;
+}
+.pillWin .ringWrap {
+  margin: 0;
+  flex: none;
+}
+.pillWin .ringSvg {
+  width: 44px;
+  height: 44px;
+}
+.pillWin .ringTrack,
+.pillWin .ringProgress {
+  stroke-width: 11;
+}
+.pillWin .outOf {
+  display: none;
+}
+.pillText {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pillWin .headline {
+  margin: 0;
+}
+
+/* Compact error mark for the pill error row: same danger tint as the full badge,
+ * sized to sit inside the single pill row where the ring would otherwise be. */
+.pillErrorBadge {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--danger));
+  background: rgba(var(--danger), 0.12);
+}
+
+/* Inline (auto-width) action used by the pill row: same look, compact box. */
+.ctaInline {
+  width: auto;
+  flex: none;
+  height: 34px;
+  margin-top: 0;
+  padding: 0 var(--space-3-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ringProgress,
+  .toGoBar i,
+  .cta {
+    transition: none;
+  }
+  .ringGlow,
+  .verifiedLine {
+    animation: none;
+  }
+}

--- a/src/redesign/ScoreWindow.stories.tsx
+++ b/src/redesign/ScoreWindow.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { ScoreWindow } from "./ScoreWindow";
+import { PassportShell } from "./PassportShell";
+import { ThemePair, SAMPLE_ACCOUNT } from "./storyFrame";
+
+/**
+ * ScoreWindow - the home / spine, in every state, composed inside the shell so
+ * the overlay rules (nothing outside the shell, ring not clipped, tooltips never
+ * clipped) are visible. Both themes, no network.
+ */
+const meta: Meta<typeof ScoreWindow> = {
+  title: "Redesign/Score Window",
+  component: ScoreWindow,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof ScoreWindow>;
+
+const inShell = (node: React.ReactNode) => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT}>{node}</PassportShell>
+  </ThemePair>
+);
+
+export const Loading: Story = {
+  name: "Score / Loading",
+  render: () => inShell(<ScoreWindow state="loading" />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interim loading state: a simple indeterminate emerald arc. This will be replaced by the shared Cryptex loader from @holonym-foundation/ui once that package is installable as a dependency (its source is not copied into this public repo).",
+      },
+    },
+  },
+};
+
+export const BelowThreshold: Story = {
+  name: "Score / Below threshold",
+  render: () =>
+    inShell(
+      <ScoreWindow
+        state="below"
+        score={17}
+        threshold={20}
+        addVerificationsCta={{ onClick: () => undefined }}
+        linkIdentityCta={{ onClick: () => undefined }}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Below the threshold the ring is amber, not emerald. Hover the score for its state and the tap-to-compute hint. Two configurable CTAs share one box metric (both full width, identical height and padding): the emerald 'Add verifications' primary and the tonal 'Link an identity' secondary, the latter with a chain-link icon. Both sit in the bottom-pinned action area so the primary CTA lands at the same y as the verified Continue.",
+      },
+    },
+  },
+};
+
+export const Verified: Story = {
+  name: "Score / Verified (reward)",
+  render: () => inShell(<ScoreWindow state="verified" score={24} threshold={20} onContinue={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Crossing the threshold is a reward: the ring completes in emerald and a glow pulses. There is no badge inside the ring. The green check sits inline with 'You're verified' and animates in with the text. Hover the check for 'Score 24. Above the threshold.' A single 'Continue' hand-off CTA.",
+      },
+    },
+  },
+};
+
+export const ErrorState: Story = {
+  name: "Score / Error",
+  render: () => inShell(<ScoreWindow state="error" errorKind="network" onRetry={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story: "Humanized error copy mapped from the failure kind (network here), never a raw error.message, plus a retry CTA.",
+      },
+    },
+  },
+};

--- a/src/redesign/ScoreWindow.tsx
+++ b/src/redesign/ScoreWindow.tsx
@@ -1,0 +1,430 @@
+import React from "react";
+import styles from "./ScoreWindow.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import { CheckIcon, LinkIcon, PlusIcon, RetryIcon } from "./icons";
+import { useCountUp, useReducedMotion } from "./hooks";
+import { humanizeError, ErrorKind } from "./humanizeError";
+import type { ShellSize } from "./PassportShell";
+
+export type ScoreWindowState = "loading" | "below" | "verified" | "error";
+
+/** A dev-configurable call to action. Omit `onClick` to leave it inert; set
+ *  `hidden` to drop it from the action area entirely. */
+export type ShellCta = {
+  label?: string;
+  onClick?: () => void;
+  hidden?: boolean;
+};
+
+export type ScoreWindowProps = {
+  state: ScoreWindowState;
+  /** Current humanity score (below / verified states). */
+  score?: number;
+  /** Passing threshold. The single source of truth for it comes from score data. */
+  threshold?: number;
+  /** Tap the score (ring / number) to open the drill-down. */
+  onDrilldown?: () => void;
+
+  /** Below-threshold action area, CTA 1: add stamps / verifications. */
+  addVerificationsCta?: ShellCta;
+  /** Below-threshold action area, CTA 2: link an identity (a wallet / account)
+   *  to import reputation. Present in the onboarding / below-threshold flow,
+   *  dev-invokable. */
+  linkIdentityCta?: ShellCta;
+
+  /** Verified hand-off CTA (Continue back to the host app). */
+  onContinue?: () => void;
+  /** Override the verified hand-off CTA label. */
+  continueLabel?: string;
+
+  /** Retry handler for the error state. */
+  onRetry?: () => void;
+  /** Error kind, or the thrown value, mapped to friendly copy (never a raw
+   *  error.message). */
+  errorKind?: ErrorKind;
+  error?: unknown;
+  /** Optional explicit override of the humanized error message. */
+  errorMessage?: string;
+
+  /** Override the default per-state headline. */
+  headline?: string;
+  /** Override the default per-state subtext. */
+  subtext?: string;
+
+  /**
+   * Pill-only: the account name / short address preview shown between the score
+   * ring and the action on the single pill row (e.g. "Shady.eth" or
+   * "0x1332…4a9f"). Ignored by the full / mini layouts, which carry the account
+   * in the shell chrome instead.
+   */
+  accountPreview?: string;
+
+  /**
+   * Size variant, mirrors the shell's. `full` (default) is the crafted card;
+   * `mini` is a condensed ~half-size card; `pill` is a compact single-row pill
+   * (mark + score + one action). Pass the SAME value you pass to PassportShell.
+   */
+  size?: ShellSize;
+
+  /**
+   * Customization-API knob: render the action button or not. Defaults to `true`.
+   * When `false`, the window shows a status-only readout with no action button
+   * (score + preview / message only). Most useful on the `pill` size to ship a
+   * read-only status pill, but honored on every size and state.
+   */
+  showAction?: boolean;
+};
+
+const RING_RADIUS = 54;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+const COUNT_MS = 1000;
+
+/** Loader diameter (px) per shell size variant. */
+const LOADER_PX: Record<ShellSize, number> = { full: 116, mini: 76, pill: 40 };
+
+/** True circular progress ring. Emerald at or above the threshold, amber below. */
+const ScoreRing: React.FC<{
+  fill: number; // 0..1
+  passing: boolean;
+  celebrate?: boolean;
+  reduced: boolean;
+  children: React.ReactNode;
+}> = ({ fill, passing, celebrate, reduced, children }) => {
+  const target = Math.max(0, Math.min(1, fill));
+  const [offset, setOffset] = React.useState(reduced ? RING_CIRCUMFERENCE * (1 - target) : RING_CIRCUMFERENCE);
+
+  React.useEffect(() => {
+    if (reduced) {
+      setOffset(RING_CIRCUMFERENCE * (1 - target));
+      return;
+    }
+    setOffset(RING_CIRCUMFERENCE);
+    const raf = requestAnimationFrame(() => setOffset(RING_CIRCUMFERENCE * (1 - target)));
+    return () => cancelAnimationFrame(raf);
+  }, [target, reduced]);
+
+  return (
+    <div className={`${styles.ringWrap} ${celebrate ? styles.celebrate : ""}`}>
+      {celebrate ? <span className={styles.ringGlow} aria-hidden="true" /> : null}
+      <svg className={styles.ringSvg} viewBox="0 0 150 150" aria-hidden="true">
+        <circle className={styles.ringTrack} cx="75" cy="75" r={RING_RADIUS} />
+        <circle
+          className={`${styles.ringProgress} ${passing ? styles.ringPass : styles.ringWarn}`}
+          cx="75"
+          cy="75"
+          r={RING_RADIUS}
+          transform="rotate(-90 75 75)"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={offset}
+        />
+      </svg>
+      <div className={styles.ringNum}>{children}</div>
+    </div>
+  );
+};
+
+/**
+ * Interim loader for the score-loading state: a simple indeterminate emerald arc.
+ * TODO: swap to the shared Cryptex loader from `@holonym-foundation/ui` once that
+ * package is installable by this build. Do NOT vendor its source into this public
+ * repo. Consume it as a dependency (see design-sop §7 reuse-shared-components).
+ */
+const ScoreLoader: React.FC<{ size: ShellSize }> = ({ size }) => {
+  const reduced = useReducedMotion();
+  const px = LOADER_PX[size];
+  return (
+    <div className={styles.ringWrap} role="status" aria-label="Checking your score">
+      <svg width={px} height={px} viewBox="0 0 48 48" aria-hidden className={reduced ? undefined : styles.spin}>
+        <circle cx="24" cy="24" r="20" fill="none" stroke="rgba(var(--muted), 0.25)" strokeWidth="4" />
+        <path d="M24 4 a20 20 0 0 1 20 20" fill="none" stroke="rgb(var(--accent))" strokeWidth="4" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+};
+
+/** One action button. Emerald primary or tonal secondary. All action buttons
+ *  share ONE box metric (full width, same height + padding); only color differs. */
+const ActionButton: React.FC<{
+  variant: "primary" | "secondary";
+  onClick?: () => void;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ variant, onClick, icon, children }) => (
+  <button
+    type="button"
+    className={`${styles.cta} ${variant === "secondary" ? styles.ctaSecondary : ""}`}
+    onClick={onClick}
+  >
+    <span className={styles.ctaIcon}>{icon}</span>
+    <span className={styles.ctaLabel}>{children}</span>
+  </button>
+);
+
+export const ScoreWindow: React.FC<ScoreWindowProps> = ({
+  state,
+  score = 0,
+  threshold = 20,
+  onDrilldown,
+  addVerificationsCta,
+  linkIdentityCta,
+  onContinue,
+  continueLabel,
+  onRetry,
+  errorKind,
+  error,
+  errorMessage,
+  headline,
+  subtext,
+  accountPreview,
+  size = "full",
+  showAction = true,
+}) => {
+  const reduced = useReducedMotion();
+  const toGo = Math.max(0, Math.ceil(threshold - score));
+  const fill = threshold > 0 ? score / threshold : 0;
+  const counted = useCountUp(score, COUNT_MS, reduced || state === "loading" || state === "error");
+  const shownScore = Math.round(counted);
+  const compact = size !== "full";
+  const verified = state === "verified";
+  const roundedScore = Math.round(score);
+  const winClass = `${styles.window} ${size === "mini" ? styles.miniWin : ""} ${size === "pill" ? styles.pillWin : ""}`;
+
+  const addCta = addVerificationsCta ?? {};
+  const idCta = linkIdentityCta ?? {};
+
+  // The score (ring + number) is itself the hover / tap target: the tooltip
+  // tells the user the state and that they can tap to see how it is computed.
+  // (Only meaningful for the below / verified states.)
+  const ringTip = verified ? (
+    <>
+      Verified and above the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+    </>
+  ) : (
+    <>
+      {toGo} more to reach the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+    </>
+  );
+  const ringLabel = verified
+    ? "Verified and above the threshold. Tap to see how your score is computed."
+    : `${toGo} more to reach the threshold. Tap to see how your score is computed.`;
+
+  const ringButton = (
+    <Tooltip content={ringTip} placement="top" className={glass.tip}>
+      <button type="button" className={styles.ringButton} onClick={onDrilldown} aria-label={ringLabel}>
+        <ScoreRing fill={verified ? 1 : fill} passing={verified} celebrate={verified && !compact} reduced={reduced}>
+          <span className={styles.scoreWrap}>
+            <span className={styles.count}>{shownScore}</span>
+            {verified ? null : <small className={styles.outOf}>/{threshold}</small>}
+          </span>
+        </ScoreRing>
+      </button>
+    </Tooltip>
+  );
+
+  // ---- pill: one true single short row in EVERY state. loading = small loader
+  // + short label; below = small ring + "N to go" + a compact action; verified =
+  // ring + account preview + Continue; error = compact message + retry. With
+  // showAction={false} the action drops and the pill is a status-only readout
+  // (score / message + preview). No "Verified" word, no footer here (the shell
+  // owns the compact footer); the only tooltip is the score-hover on the ring. ----
+  if (size === "pill") {
+    if (state === "loading") {
+      return (
+        <div className={winClass}>
+          <ScoreLoader size="pill" />
+          <span className={styles.pillText}>{headline ?? "Checking your score"}</span>
+        </div>
+      );
+    }
+
+    if (state === "error") {
+      const human = humanizeError(errorKind ?? error);
+      // Keep the pill to one short row: the compact title, not the full sentence.
+      const message = errorMessage ?? subtext ?? human.title;
+      return (
+        <div className={winClass}>
+          <span className={styles.pillErrorBadge} aria-hidden="true">
+            <RetryIcon size={16} />
+          </span>
+          <span className={styles.pillText} role="alert">
+            {message}
+          </span>
+          {showAction && human.retryable && onRetry ? (
+            <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onRetry}>
+              <span className={styles.ctaIcon}>
+                <RetryIcon size={14} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>Retry</span>
+            </button>
+          ) : null}
+        </div>
+      );
+    }
+
+    // below / verified: ring + label + one action. Below shows "N to go"; verified
+    // shows the account preview.
+    const pillLabel = verified ? accountPreview : `${toGo} to go`;
+    return (
+      <div className={winClass}>
+        <p className={styles.srOnly} aria-live="polite">
+          Score {roundedScore} of {threshold}. {verified ? "Above the threshold." : `${toGo} to go.`}
+        </p>
+        {ringButton}
+        {pillLabel ? <span className={styles.pillText}>{pillLabel}</span> : <span className={styles.pillText} />}
+        {!showAction ? null : verified ? (
+          <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onContinue}>
+            <span className={styles.ctaLabel}>{continueLabel ?? "Continue"}</span>
+          </button>
+        ) : addCta.hidden ? null : (
+          <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={addCta.onClick}>
+            <span className={styles.ctaIcon}>
+              <PlusIcon size={14} strokeWidth={2} />
+            </span>
+            <span className={styles.ctaLabel}>{addCta.label ?? "Verify"}</span>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (state === "loading") {
+    return (
+      <div className={winClass}>
+        <ScoreLoader size={size} />
+        <p className={styles.headline}>{headline ?? "Checking your score"}</p>
+        <p className={styles.sub}>{subtext ?? "This only takes a moment."}</p>
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    const human = humanizeError(errorKind ?? error);
+    const title = headline ?? human.title;
+    const message = errorMessage ?? subtext ?? human.message;
+    return (
+      <div className={winClass}>
+        <div className={styles.errorBadge} aria-hidden="true">
+          <RetryIcon size={22} />
+        </div>
+        <p className={styles.headline}>{title}</p>
+        <p className={styles.sub} role="alert">
+          {message}
+        </p>
+        {showAction && human.retryable && onRetry ? (
+          <ActionButton variant="primary" onClick={onRetry} icon={<RetryIcon size={15} strokeWidth={2} />}>
+            Try again
+          </ActionButton>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className={winClass}>
+      <p className={styles.srOnly} aria-live="polite">
+        Score {roundedScore} of {threshold}. {verified ? "Above the threshold." : `${toGo} to go.`}
+      </p>
+
+      {ringButton}
+
+      {verified ? (
+        compact ? (
+          // mini: no standalone verified line. The verified state folds into the
+          // CTA itself (check + "You're verified"), which continues on tap. Ring
+          // + this one button + footer, nothing else, to save vertical space.
+          // With showAction={false} it becomes a static, non-interactive line.
+          showAction ? (
+            <button type="button" className={styles.cta} onClick={onContinue}>
+              <span className={styles.ctaIcon}>
+                <CheckIcon size={15} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>{headline ?? "You're verified"}</span>
+            </button>
+          ) : (
+            <div className={`${styles.verifiedLine} ${reduced ? styles.verifiedLineStatic : ""}`}>
+              <span className={styles.inlineSeal} aria-hidden="true">
+                <CheckIcon size={14} strokeWidth={2.6} />
+              </span>
+              <span className={styles.verifiedText}>{headline ?? "You're verified"}</span>
+            </div>
+          )
+        ) : (
+          <>
+            <div className={`${styles.verifiedLine} ${reduced ? styles.verifiedLineStatic : ""}`}>
+              {/* The external seal / check now sits inline with the headline, and
+                  animates in together with the text. Its tooltip carries the
+                  "Score N. Above the threshold" detail, and it is tappable. */}
+              <Tooltip
+                content={
+                  <>
+                    <b>Score {roundedScore}.</b> Above the threshold. <em>Tap to see how it&rsquo;s computed.</em>
+                  </>
+                }
+                placement="top"
+                className={glass.tip}
+              >
+                <button
+                  type="button"
+                  className={styles.inlineSeal}
+                  onClick={onDrilldown}
+                  aria-label={`Score ${roundedScore}. Above the threshold. Tap to see how it's computed.`}
+                >
+                  <CheckIcon size={14} strokeWidth={2.6} />
+                </button>
+              </Tooltip>
+              <span className={styles.verifiedText}>{headline ?? "You're verified"}</span>
+            </div>
+
+            {showAction ? (
+              <button type="button" className={styles.cta} onClick={onContinue}>
+                <span className={styles.ctaIcon}>
+                  <CheckIcon size={15} strokeWidth={2} />
+                </span>
+                <span className={styles.ctaLabel}>{continueLabel ?? "Continue"}</span>
+              </button>
+            ) : null}
+          </>
+        )
+      ) : (
+        <>
+          <p className={styles.headline}>{headline ?? "Almost verified"}</p>
+          {compact ? null : <p className={styles.sub}>{subtext ?? "You need a little more to pass."}</p>}
+
+          {compact ? null : (
+            <div className={styles.toGo}>
+              <span className={styles.toGoBar}>
+                <i style={{ width: `${Math.min(100, fill * 100)}%` }} />
+              </span>
+              <span className={styles.toGoLabel}>{toGo} to go</span>
+            </div>
+          )}
+
+          {showAction ? (
+            <div className={styles.actions}>
+              {addCta.hidden ? null : (
+                <ActionButton
+                  variant="primary"
+                  onClick={addCta.onClick}
+                  icon={<PlusIcon size={15} strokeWidth={2} />}
+                >
+                  {addCta.label ?? "Add verifications"}
+                </ActionButton>
+              )}
+              {/* mini keeps only the primary action so it stays half-size. */}
+              {compact || idCta.hidden ? null : (
+                <ActionButton
+                  variant="secondary"
+                  onClick={idCta.onClick}
+                  icon={<LinkIcon size={15} strokeWidth={1.9} />}
+                >
+                  {idCta.label ?? "Link an identity"}
+                </ActionButton>
+              )}
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/redesign/SecuredByFooter.module.css
+++ b/src/redesign/SecuredByFooter.module.css
@@ -1,0 +1,33 @@
+/*
+ * Shared "Secured by human.tech" lockup. Consistent icon, font, size, position,
+ * and margin so it renders identically in every shell state (§ harmonized
+ * footer). No hard lines: separation from content is spacing only.
+ */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: var(--space-4-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgba(var(--on-surface), 0.7);
+}
+
+/* Compact form for the single-row pill: smaller mark + text, tight top margin so
+ * the whole widget still reads as one short pill (§ pill footer). */
+.compact {
+  gap: 4px;
+  margin-top: var(--space-2-c6dbf459);
+  font-size: calc(var(--font-size-xs-c6dbf459) * 0.9);
+}
+
+.mark {
+  display: block;
+  opacity: 0.75;
+}
+
+.text {
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.01em;
+}

--- a/src/redesign/SecuredByFooter.tsx
+++ b/src/redesign/SecuredByFooter.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import styles from "./SecuredByFooter.module.css";
+import { ShieldIcon } from "./icons";
+
+/**
+ * SecuredByFooter - the single shared "Secured by human.tech" lockup (§ shell
+ * chrome). One component, one icon + font + size + position + margin, so the
+ * footer is byte-for-byte identical across every shell state (score, account,
+ * drill-down, loading, error). Import this everywhere the lockup appears; never
+ * re-inline the icon + text.
+ */
+export const SecuredByFooter: React.FC<{ className?: string; compact?: boolean }> = ({
+  className = "",
+  compact = false,
+}) => (
+  <div className={`${styles.footer} ${compact ? styles.compact : ""} ${className}`}>
+    <ShieldIcon className={styles.mark} size={compact ? 10 : 12} />
+    <span className={styles.text}>Secured by human.tech</span>
+  </div>
+);

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -472,40 +472,15 @@
   outline-offset: 2px;
 }
 
-/* ---- how the score is computed: weighted components summing to the total ---- */
-.compute {
-  flex: none;
-  margin-top: var(--space-3-c6dbf459);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1-c6dbf459);
-}
-.computeHead {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-2-c6dbf459);
-}
-.computeLabel {
-  font-size: var(--font-size-xs-c6dbf459);
-  font-weight: var(--weight-medium-c6dbf459);
-  letter-spacing: 0.04em;
-  color: rgba(var(--on-surface), 0.62);
-}
-.computeTotal {
-  flex: none;
-  font-size: var(--font-size-xs-c6dbf459);
-  font-weight: var(--weight-bold-c6dbf459);
-  color: rgb(var(--on-surface));
-  font-variant-numeric: tabular-nums;
-}
 /* The weighted bar: segment LENGTH encodes each component's share; one accent
- * family (deriveTints), no legend (points ride on the rows above). */
+ * family (deriveTints), no legend and no number (points ride on the rows above,
+ * the total is stated once in the header). Sits inside the breakdown accordion. */
 .computeBar {
   display: flex;
   align-items: stretch;
   gap: 2px;
   height: 8px;
+  margin-top: var(--space-2-c6dbf459);
   border-radius: var(--radius-pill-c6dbf459);
   overflow: hidden;
   background: rgba(var(--on-surface), 0.08);
@@ -516,22 +491,22 @@
   border-radius: var(--radius-pill-c6dbf459);
 }
 
-/* ---- onchain credential: a collapsible metadata block (Human ID SBTs only) --- */
-/* Collapsed it is a single tonal row (fits trivially); expanded it shows a compact
- * two-column grid + a View on chain link. Kept small so an open block still fits
- * the fixed drawer height alongside the one SBT component row (never scrolls). */
-.oc {
+/* ---- accordion sections: Score breakdown + Onchain credential ---------------- */
+/* An accordion GROUP (at most one open) so an expanded section always fits the
+ * fixed drawer height. Collapsed each is a single tonal header row; expanded it
+ * reveals its rows. Structure is tone + space, not hard lines (§ no-hard-lines). */
+.section {
   flex: none;
   margin-top: var(--space-3-c6dbf459);
 }
-.ocHead {
+.sectionHead {
   appearance: none;
   border: 0;
   width: 100%;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 5px var(--space-2-c6dbf459);
+  padding: 6px var(--space-2-c6dbf459);
   border-radius: var(--radius-md-c6dbf459);
   background: rgba(var(--on-surface), 0.05);
   color: rgb(var(--on-surface));
@@ -540,33 +515,67 @@
   font-size: var(--font-size-xs-c6dbf459);
   font-weight: var(--weight-semibold-c6dbf459);
 }
-.ocHead:hover {
+.sectionHead:hover {
   background: rgba(var(--on-surface), 0.08);
 }
-.ocHead:focus-visible {
+.sectionHead:focus-visible {
   outline: 2px solid rgb(var(--accent));
   outline-offset: -2px;
+}
+.sectionLabel {
+  flex: 1;
+  text-align: left;
+  letter-spacing: 0.02em;
+}
+.sectionChev,
+.sectionChevOpen {
+  flex: none;
+  color: rgba(var(--on-surface), 0.6);
+  transition: transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.sectionChevOpen {
+  transform: rotate(180deg);
+}
+.sectionBody {
+  padding: var(--space-2-c6dbf459) 2px 0;
 }
 .ocHeadIcon {
   display: inline-flex;
   color: rgb(var(--accent));
 }
-.ocHeadLabel {
-  flex: 1;
-  text-align: left;
-  letter-spacing: 0.02em;
-}
-.ocChev,
-.ocChevOpen {
-  flex: none;
-  color: rgba(var(--on-surface), 0.6);
-  transition: transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
-}
-.ocChevOpen {
-  transform: rotate(180deg);
-}
 .ocBody {
-  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459) 0;
+  padding: var(--space-2-c6dbf459) var(--space-2-c6dbf459) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+/* Protocol + chain line, led by the chain logo (never the word alone). */
+.ocProtocol {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+.ocChain {
+  display: inline-flex;
+  flex: none;
+  color: rgb(var(--on-surface));
+}
+.ocProtocolText {
+  letter-spacing: 0.01em;
+}
+
+/* Compact plain line for the Issued / Expires (and the Clean Hands privacy note),
+ * so dates and the encryption line sit on one row without a label column. */
+.ocLine {
+  margin: 0;
+  font-size: var(--font-size-xs-c6dbf459);
+  line-height: 1.35;
+  color: rgba(var(--on-surface), 0.7);
+  font-variant-numeric: tabular-nums;
 }
 /* One readable column: each row is Label ... value, so long values (dates,
  * "Proof of Clean Hands") never truncate. Compact line-height keeps the six rows
@@ -607,6 +616,35 @@
 }
 .ocVal[data-revoked="true"] {
   color: rgb(var(--warn));
+}
+/* Verified issuer: a named on-chain identity (human.tech) with a small check,
+ * linking to view the issuer / attester on chain. Never a raw hex address. */
+.ocIssuer {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+  text-decoration: none;
+}
+a.ocIssuer:hover {
+  text-decoration: underline;
+}
+a.ocIssuer:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+  border-radius: var(--radius-sm-c6dbf459);
+}
+.ocVerifiedMark {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-accent));
+  background: rgb(var(--accent));
 }
 .ocView {
   display: inline-flex;
@@ -751,8 +789,8 @@
   .back,
   .pagerArrow,
   .pagerDot,
-  .ocChev,
-  .ocChevOpen {
+  .sectionChev,
+  .sectionChevOpen {
     transition: none;
   }
 }

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -232,12 +232,15 @@
   background: rgb(var(--accent));
   color: rgb(var(--on-accent));
 }
+/* Mintable: emerald outline invite, never gold. Distinct from the solid minted
+ * pill by being a lighter fill + ring with an outlined chain dot. */
 .statusPill[data-onchain="mintable"] {
-  background: rgba(var(--warn), 0.18);
+  background: rgba(var(--accent), 0.1);
+  box-shadow: inset 0 0 0 1px rgba(var(--accent), 0.4);
 }
 .statusPill[data-onchain="mintable"] .statusDot {
-  background: rgb(var(--warn));
-  color: rgb(var(--on-warn));
+  background: rgba(var(--accent), 0.25);
+  color: rgb(var(--accent));
 }
 .statusPill[data-onchain="none"] {
   color: rgba(var(--on-surface), 0.72);
@@ -251,56 +254,73 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* One plain description line, clamped so it never grows the fixed header. */
-.desc {
+/* Timer: a small clock whose tooltip carries the whole-stamp validity / renewal
+ * copy, so that long line no longer crowds the header. Amber ONLY when expiring
+ * soon (the sanctioned small indicator); muted (never amber) once expired. */
+.timer {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  background: rgba(var(--on-surface), 0.08);
+  cursor: help;
+}
+.timer:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.timer[data-state="soon"] {
+  color: rgb(var(--warn));
+  background: rgba(var(--warn), 0.15);
+}
+.timer[data-state="expired"] {
+  color: rgba(var(--on-surface), 0.5);
+  background: rgba(var(--on-surface), 0.08);
+}
+
+/* Description: clamped to two lines with an inline "more" toggle, so the full
+ * text is always reachable and never dead-ends in a truncation. */
+.descWrap {
   margin: var(--space-2-c6dbf459) 0 0;
   flex: none;
+}
+.desc {
+  margin: 0;
   font-size: var(--font-size-sm-c6dbf459);
   line-height: var(--line-normal-c6dbf459);
   color: rgba(var(--on-surface), 0.72);
   display: -webkit-box;
-  -webkit-line-clamp: 1;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
-
-/* ---- expiry line: whole-stamp validity, stated once, plain + dash-free ---- */
-.expiry {
-  margin-top: var(--space-2-c6dbf459);
-  flex: none;
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
+.descOpen {
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+.moreBtn {
+  appearance: none;
+  border: 0;
+  margin-top: 2px;
+  padding: 0;
+  background: transparent;
+  color: rgb(var(--accent));
+  font-family: inherit;
   font-size: var(--font-size-xs-c6dbf459);
-  line-height: var(--line-tight-c6dbf459);
-  color: rgba(var(--on-surface), 0.7);
-}
-.expiryIcon {
-  display: inline-flex;
-  flex: none;
-  margin-top: 1px;
-  color: rgba(var(--on-surface), 0.55);
-}
-.expiry[data-state="soon"] .expiryIcon,
-.expiry[data-state="soon"] .expiryText {
-  color: rgb(var(--warn));
-}
-.expiry[data-state="expired"] {
   font-weight: var(--weight-semibold-c6dbf459);
+  cursor: pointer;
 }
-.expiry[data-state="expired"] .expiryIcon,
-.expiry[data-state="expired"] .expiryText {
-  color: rgb(var(--warn));
+.moreBtn:hover {
+  text-decoration: underline;
 }
-.expiryText {
-  min-width: 0;
-}
-.expiryNote {
-  color: rgba(var(--on-surface), 0.55);
-  font-weight: var(--weight-regular-c6dbf459);
-}
-.expiry[data-state="expired"] .expiryNote {
-  color: rgba(var(--on-surface), 0.55);
+.moreBtn:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+  border-radius: var(--radius-sm-c6dbf459);
 }
 
 /* ---- sub-credential rows: grow to fill, pushing the pager + action down ---- */
@@ -366,6 +386,16 @@
   gap: 4px;
   font-size: var(--font-size-xs-c6dbf459);
   color: rgba(var(--on-surface), 0.62);
+  white-space: nowrap;
+}
+/* SBT metadata sub-line (issued / id / chain). Rendered only when the research
+ * pass supplies StampComponent.sbt; a quiet caption under the component name. */
+.rowSbt {
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.5);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .rowPoints {
@@ -520,8 +550,9 @@
   padding: 0 var(--space-3-c6dbf459);
 }
 
-/* ONE shared button box (matches the Score / Stamps windows). Emerald primary by
- * default; the reward variant is gold; the secondary is tonal. Only color shifts. */
+/* ONE shared button box (matches the Score / Stamps windows). Emerald primary for
+ * every action (Notarize / Claim / View), including mint; the secondary (renew)
+ * is tonal. Only color / weight shifts; no gold anywhere. */
 .cta {
   appearance: none;
   border: 0;
@@ -562,16 +593,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-/* Gold reward CTA: the mint action. Warm gold (the same amber "reward" token as
- * the mintable pip), legible black-on-gold text in both themes. */
-.ctaReward {
-  background: rgb(var(--warn));
-  color: rgb(var(--on-warn));
-}
-.ctaReward:focus-visible {
-  outline-color: rgb(var(--warn));
 }
 
 /* Secondary (renew): tonal, no hard line, quieter than the primary. */

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -1,0 +1,591 @@
+/*
+ * StampDetailDrawer - a passport-style slide-in drawer over the Stamps window
+ * (SOP §4). A scrim dims + blurs the grid behind; the drawer is a solid glass
+ * bottom sheet that slides up. Tokens only (§1), legible in both themes (§2/§8),
+ * structure from space + tone not hard lines (§ no-hard-lines), paginate never
+ * scroll (§ windows), all motion degrades under reduced-motion (§4). Everything
+ * lives INSIDE the shell content region: the overlay fills its container and
+ * clips the sliding sheet; nothing escapes the shell.
+ */
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- scrim: the ONE translucent layer. Dims + blurs the grid behind. ---- */
+.scrim {
+  appearance: none;
+  border: 0;
+  position: absolute;
+  inset: 0;
+  padding: 0;
+  cursor: pointer;
+  /* Veil toward the surface so the grid recedes in BOTH themes (washes out on a
+   * white surface, darkens on a near-black one), plus a soft blur for depth. */
+  background: rgba(var(--surface), 0.55);
+  -webkit-backdrop-filter: blur(3px) saturate(1.05);
+  backdrop-filter: blur(3px) saturate(1.05);
+  opacity: 0;
+  transition: opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.overlay[data-open="true"] .scrim {
+  opacity: 1;
+}
+
+/* ---- the sheet: a solid glass drawer that slides up from the bottom ---- */
+/* Leaves a strip of dimmed grid visible at the top so it reads as a drawer over
+ * the window, not a full replacement. Absolutely bottom-pinned with a definite
+ * height, so the inner flex column can pin the action area to the bottom. */
+.drawer {
+  position: absolute;
+  top: var(--space-3-c6dbf459);
+  left: 0;
+  right: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2-c6dbf459) var(--space-3-c6dbf459) 0;
+  border-radius: var(--radius-lg-c6dbf459) var(--radius-lg-c6dbf459) 0 0;
+  /* Elevated, near-opaque surface: lifts off the scrim as a distinct layer in
+   * both themes (darkens slightly on white, lightens slightly on near-black),
+   * so content stays legible over the blurred grid without stacking translucency.
+   * Blur + shadow carry the separation instead of a hard border. */
+  background:
+    linear-gradient(rgba(var(--on-surface), 0.05), rgba(var(--on-surface), 0.05)),
+    rgba(var(--surface), 0.98);
+  box-shadow:
+    0 -10px 30px rgba(0, 0, 0, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  /* Slide up from below (transform none at rest so a tooltip trigger inside is
+   * never trapped in a transformed containing block). */
+  transform: translateY(102%);
+  opacity: 0;
+  transition:
+    transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    opacity var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.overlay[data-open="true"] .drawer {
+  transform: none;
+  opacity: 1;
+}
+/* First-mount enter: fade + slide even when mounted already open (§ panels fade,
+ * never pop). */
+@starting-style {
+  .overlay[data-open="true"] .drawer {
+    transform: translateY(102%);
+    opacity: 0;
+  }
+  .overlay[data-open="true"] .scrim {
+    opacity: 0;
+  }
+}
+
+/* ---- handle row: drag handle (a close affordance) + back button ---- */
+.handleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  flex: none;
+}
+.handle {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: var(--space-1-c6dbf459) 0;
+  cursor: pointer;
+  border-radius: var(--radius-md-c6dbf459);
+}
+.handleBar {
+  width: 34px;
+  height: 4px;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.22);
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.handle:hover .handleBar {
+  background: rgba(var(--on-surface), 0.36);
+}
+.handle:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.back {
+  appearance: none;
+  border: 0;
+  position: relative;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.66);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+/* Invisible >=40px hit target (a11y §8): 26px + 2×7px = 40px. */
+.back::before {
+  content: "";
+  position: absolute;
+  inset: -7px;
+}
+.back:hover {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.back:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+/* Balances the back button so the handle stays optically centered. */
+.handleSpacer {
+  width: 26px;
+  flex: none;
+}
+
+/* ---- header: medallion + name + total points + on-chain status pill ---- */
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3-c6dbf459);
+  flex: none;
+  margin-top: var(--space-1-c6dbf459);
+}
+.headMeta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+  min-width: 0;
+}
+.name {
+  margin: 0;
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.headSub {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  min-width: 0;
+}
+
+/* On-chain status pill: the ONE carrier of on-chain state in the header (the
+ * medallion drops its pip). Colored by state; a small glass tooltip explains it. */
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px 2px 6px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  cursor: help;
+  color: rgb(var(--on-surface));
+  background: rgba(var(--on-surface), 0.08);
+}
+.statusPill:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.statusDot {
+  width: 15px;
+  height: 15px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  background: rgba(var(--on-surface), 0.2);
+  color: rgb(var(--on-surface));
+}
+.statusPill[data-onchain="minted"] {
+  background: rgba(var(--accent), 0.16);
+}
+.statusPill[data-onchain="minted"] .statusDot {
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+}
+.statusPill[data-onchain="mintable"] {
+  background: rgba(var(--warn), 0.18);
+}
+.statusPill[data-onchain="mintable"] .statusDot {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-warn));
+}
+.statusPill[data-onchain="none"] {
+  color: rgba(var(--on-surface), 0.72);
+}
+
+.headPoints {
+  flex: none;
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgba(var(--on-surface), 0.8);
+  font-variant-numeric: tabular-nums;
+}
+
+/* One plain description line, clamped so it never grows the fixed header. */
+.desc {
+  margin: var(--space-2-c6dbf459) 0 0;
+  flex: none;
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ---- sub-credential rows: grow to fill, pushing the pager + action down ---- */
+.list {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+  margin-top: var(--space-3-c6dbf459);
+  align-content: flex-start;
+  /* Safety only: the page size is tuned so rows always fit, so this never has to
+   * clip. It guarantees a scrollbar can NEVER appear inside the shell (§ never
+   * scroll), even if an integrator overrides componentsPerPage too high. */
+  overflow: hidden;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  /* Tonal band, not a hard line (§ no-hard-lines). */
+  background: rgba(var(--on-surface), 0.05);
+}
+.row[data-verified="false"] {
+  background: rgba(var(--on-surface), 0.03);
+}
+.rowIcon {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  border-radius: var(--radius-sm-c6dbf459);
+  display: grid;
+  place-items: center;
+  font-size: 15px;
+  line-height: 1;
+  color: rgba(var(--on-surface), 0.82);
+  background: rgba(var(--on-surface), 0.07);
+}
+.row[data-verified="false"] .rowIcon {
+  opacity: 0.6;
+}
+.rowMeta {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+.rowName {
+  font-size: var(--font-size-sm-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rowState {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+  white-space: nowrap;
+}
+.rowPoints {
+  flex: none;
+  padding: 1px 8px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  color: rgba(var(--on-surface), 0.7);
+  background: rgba(var(--on-surface), 0.1);
+}
+.row[data-verified="true"] .rowPoints {
+  color: rgb(var(--on-accent));
+  background: rgb(var(--accent));
+}
+
+/* ---- pager: dots + arrows, never a scrollbar (matches the Stamps window) ---- */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 0;
+  flex: none;
+}
+.pagerArrow {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- how the score is computed: weighted components summing to the total ---- */
+.compute {
+  flex: none;
+  margin-top: var(--space-3-c6dbf459);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-c6dbf459);
+}
+.computeHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2-c6dbf459);
+}
+.computeLabel {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.04em;
+  color: rgba(var(--on-surface), 0.62);
+}
+.computeTotal {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  color: rgb(var(--on-surface));
+  font-variant-numeric: tabular-nums;
+}
+/* The weighted bar: segment LENGTH encodes each component's share; one accent
+ * family (deriveTints), no legend (points ride on the rows above). */
+.computeBar {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  height: 8px;
+  border-radius: var(--radius-pill-c6dbf459);
+  overflow: hidden;
+  background: rgba(var(--on-surface), 0.08);
+}
+.computeSeg {
+  height: 100%;
+  min-width: 3px;
+  border-radius: var(--radius-pill-c6dbf459);
+}
+
+/* ---- action area: bottom-pinned, one primary action + optional renew ---- */
+.actions {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 var(--space-3-c6dbf459);
+}
+/* Two actions (primary + renew) share ONE row so the drawer keeps its single
+ * action-row height whether or not renew is present (no vertical jump, no clip). */
+.actionsRow {
+  flex-direction: row;
+  align-items: stretch;
+}
+.actionsRow > .cta,
+.actionsRow > .doneRow {
+  flex: 1;
+}
+.actionsRow > .ctaRenew {
+  flex: none;
+  width: auto;
+  padding: 0 var(--space-3-c6dbf459);
+}
+
+/* ONE shared button box (matches the Score / Stamps windows). Emerald primary by
+ * default; the reward variant is gold; the secondary is tonal. Only color shifts. */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    background var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.ctaIcon {
+  display: inline-flex;
+}
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Gold reward CTA: the mint action. Warm gold (the same amber "reward" token as
+ * the mintable pip), legible black-on-gold text in both themes. */
+.ctaReward {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-warn));
+}
+.ctaReward:focus-visible {
+  outline-color: rgb(var(--warn));
+}
+
+/* Secondary (renew): tonal, no hard line, quieter than the primary. */
+.ctaSecondary {
+  background: rgba(var(--on-surface), 0.07);
+  color: rgb(var(--on-surface));
+  box-shadow: none;
+}
+.ctaSecondary:hover {
+  filter: none;
+  background: rgba(var(--on-surface), 0.12);
+}
+/* Renew is the compact tonal step beside the primary (see .actionsRow). */
+.ctaRenew {
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+/* Verified "done" state: a calm confirmation, not a CTA (nothing left to do). It
+ * occupies the same bottom-pinned slot so the layout does not jump between states. */
+.doneRow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  height: 46px;
+  border-radius: var(--radius-lg-c6dbf459);
+  background: rgba(var(--accent), 0.12);
+}
+.doneSeal {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgb(var(--on-accent));
+  background: radial-gradient(circle at 35% 28%, rgba(255, 255, 255, 0.9), rgb(var(--accent)) 80%);
+  box-shadow: var(--shadow-sm-c6dbf459);
+}
+.doneText {
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrim,
+  .drawer,
+  .handleBar,
+  .cta,
+  .back,
+  .pagerArrow,
+  .pagerDot {
+    transition: none;
+  }
+}

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -264,6 +264,45 @@
   overflow: hidden;
 }
 
+/* ---- expiry line: whole-stamp validity, stated once, plain + dash-free ---- */
+.expiry {
+  margin-top: var(--space-2-c6dbf459);
+  flex: none;
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: var(--font-size-xs-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgba(var(--on-surface), 0.7);
+}
+.expiryIcon {
+  display: inline-flex;
+  flex: none;
+  margin-top: 1px;
+  color: rgba(var(--on-surface), 0.55);
+}
+.expiry[data-state="soon"] .expiryIcon,
+.expiry[data-state="soon"] .expiryText {
+  color: rgb(var(--warn));
+}
+.expiry[data-state="expired"] {
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+.expiry[data-state="expired"] .expiryIcon,
+.expiry[data-state="expired"] .expiryText {
+  color: rgb(var(--warn));
+}
+.expiryText {
+  min-width: 0;
+}
+.expiryNote {
+  color: rgba(var(--on-surface), 0.55);
+  font-weight: var(--weight-regular-c6dbf459);
+}
+.expiry[data-state="expired"] .expiryNote {
+  color: rgba(var(--on-surface), 0.55);
+}
+
 /* ---- sub-credential rows: grow to fill, pushing the pager + action down ---- */
 .list {
   flex: 1 1 auto;

--- a/src/redesign/StampDetailDrawer.module.css
+++ b/src/redesign/StampDetailDrawer.module.css
@@ -388,16 +388,6 @@
   color: rgba(var(--on-surface), 0.62);
   white-space: nowrap;
 }
-/* SBT metadata sub-line (issued / id / chain). Rendered only when the research
- * pass supplies StampComponent.sbt; a quiet caption under the component name. */
-.rowSbt {
-  font-size: var(--font-size-xs-c6dbf459);
-  color: rgba(var(--on-surface), 0.5);
-  font-variant-numeric: tabular-nums;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .rowPoints {
   flex: none;
   padding: 1px 8px;
@@ -526,9 +516,124 @@
   border-radius: var(--radius-pill-c6dbf459);
 }
 
+/* ---- onchain credential: a collapsible metadata block (Human ID SBTs only) --- */
+/* Collapsed it is a single tonal row (fits trivially); expanded it shows a compact
+ * two-column grid + a View on chain link. Kept small so an open block still fits
+ * the fixed drawer height alongside the one SBT component row (never scrolls). */
+.oc {
+  flex: none;
+  margin-top: var(--space-3-c6dbf459);
+}
+.ocHead {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: rgba(var(--on-surface), 0.05);
+  color: rgb(var(--on-surface));
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+.ocHead:hover {
+  background: rgba(var(--on-surface), 0.08);
+}
+.ocHead:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.ocHeadIcon {
+  display: inline-flex;
+  color: rgb(var(--accent));
+}
+.ocHeadLabel {
+  flex: 1;
+  text-align: left;
+  letter-spacing: 0.02em;
+}
+.ocChev,
+.ocChevOpen {
+  flex: none;
+  color: rgba(var(--on-surface), 0.6);
+  transition: transform var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.ocChevOpen {
+  transform: rotate(180deg);
+}
+.ocBody {
+  padding: var(--space-1-c6dbf459) var(--space-2-c6dbf459) 0;
+}
+/* One readable column: each row is Label ... value, so long values (dates,
+ * "Proof of Clean Hands") never truncate. Compact line-height keeps the six rows
+ * within the space freed by the component list stepping aside (never scrolls). */
+.ocGrid {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ocItem {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3-c6dbf459);
+  min-width: 0;
+  line-height: 1.3;
+}
+.ocKey {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  color: rgba(var(--on-surface), 0.55);
+}
+.ocVal {
+  margin: 0;
+  min-width: 0;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgb(var(--on-surface));
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Not revoked reads positive (emerald); revoked reads as a warn state. */
+.ocVal[data-revoked="false"] {
+  color: rgb(var(--accent));
+}
+.ocVal[data-revoked="true"] {
+  color: rgb(var(--warn));
+}
+.ocView {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: var(--space-1-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--accent));
+  text-decoration: none;
+  cursor: pointer;
+}
+.ocView:hover {
+  text-decoration: underline;
+}
+.ocView:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+  border-radius: var(--radius-sm-c6dbf459);
+}
+
 /* ---- action area: bottom-pinned, one primary action + optional renew ---- */
+/* margin-top:auto pins it to the bottom when there is no flex-grow list to do so
+ * (the focused onchain-credential view drops the list); inert otherwise. */
 .actions {
   flex: none;
+  margin-top: auto;
   display: flex;
   flex-direction: column;
   gap: var(--space-2-c6dbf459);
@@ -645,7 +750,9 @@
   .cta,
   .back,
   .pagerArrow,
-  .pagerDot {
+  .pagerDot,
+  .ocChev,
+  .ocChevOpen {
     transition: none;
   }
 }

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -9,10 +9,11 @@ import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS, SAMPLE_STAMP_DETAIL
  * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
  * window (modeled on app.passport.xyz's stamp drawer). A scrim dims and blurs the
  * grid behind; the drawer slides up as a solid glass sheet with a drag handle.
- * Header: real medallion icon + name + total points + on-chain status pill, plus
- * whole-stamp expiry ("Valid for N days" / "Expires {date}" / "Expired"). Then the
- * real sub-credential rows, paginated never scrolled. Then how the score is
- * computed. Then one bottom-pinned state-driven action (Notarize stamp / Claim /
+ * Header: real medallion icon + name + total points (stated once) + on-chain
+ * status pill, plus whole-stamp expiry behind the clock tooltip. Then, for
+ * multi-component stamps, a Score breakdown accordion (all components reachable,
+ * never clipped or scrolled); for SBT / attestation stamps, an Onchain credential
+ * accordion. Then one bottom-pinned state-driven action (Notarize stamp / Claim /
  * View on chain / Verified). Both themes, no network, everything inside the shell.
  */
 const meta: Meta<typeof StampDetailDrawer> = {
@@ -85,7 +86,7 @@ export const OnchainCredential: Story = {
     docs: {
       description: {
         story:
-          "The Government ID SBT with its Onchain credential block expanded. This block appears only on the four Human ID SBT stamps (Government ID, Biometrics, Phone, Proof of Clean Hands) and shows non-PII metadata only: issued date, expiry, chain (Optimism), revocation status, credential type, issuer (Human ID), and a View on chain link (the HubV3 contract on Optimism for the SBTs, the Sign Protocol attestation for Proof of Clean Hands). It never surfaces the nullifier or any personal field, and there is no fake token id. The block is collapsible so it always fits the fixed drawer height without scrolling.",
+          "The Government ID SBT with its Onchain credential accordion expanded. This block appears only on the Human ID SBT / attestation stamps and shows non-PII metadata only: the protocol and chain led by the Optimism mark (Onchain SBT · Optimism), Issued and Expires on one line, the credential type, the verified issuer as a named on-chain identity (human.tech with a check and a view-on-chain link, never raw hex), revocation status, and a View on chain link to the HubV3 contract on Optimism. It never surfaces the nullifier, the user address, or any personal field, and there is no fake token id. It is one section of an accordion group, so it always fits the fixed drawer height without scrolling.",
       },
     },
   },
@@ -111,33 +112,33 @@ export const Unverified: Story = {
     docs: {
       description: {
         story:
-          "An unverified stamp. Its component reads as not verified yet, the header shows zero points earned so far, and the how-it-computes bar is omitted because nothing is earned. There is no expiry line (nothing is verified). The action resolves to Claim, so the state is never a dead end.",
+          "An unverified stamp. The header shows zero points earned so far, and because Coinbase scores from a single credential there is no breakdown accordion to restate that. There is no expiry line (nothing is verified). The action resolves to Claim, so the state is never a dead end.",
       },
     },
   },
 };
 
 export const CleanHands: Story = {
-  name: "Stamp detail / Proof of Clean Hands SBT",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS.CleanHands),
+  name: "Stamp detail / Proof of Clean Hands (Sign Protocol)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.CleanHands, { defaultOnchainOpen: true }),
   parameters: {
     docs: {
       description: {
         story:
-          "The Proof of Clean Hands SBT. A verified, mintable credential awarded after identity verification and sanctions validation. The plain description reads in full (with a more toggle when it runs long), the header clock's tooltip carries the validity and Human ID auto renew copy, and the action is the emerald Notarize stamp so the user can put the SBT on chain.",
+          "Proof of Clean Hands is a SIGN PROTOCOL attestation, not an SBT and not EAS, so its onchain block is labeled 'Sign Protocol attestation' and its link reads 'View on Sign Protocol' (scan.sign.global). Its issued line is privacy accurate: 'Issued {date} · identity encrypted to the Human Network'. The attestation data is only a scope actionId with nothing to decode, so there is no observer and no signature shown, and the nullifier and user address are never rendered. The verified issuer is human.tech, linking to the attester on chain. The action is the emerald Notarize stamp.",
       },
     },
   },
 };
 
-export const PaginatedComponents: Story = {
-  name: "Stamp detail / Civic (paginated components)",
+export const ComponentBreakdown: Story = {
+  name: "Stamp detail / Civic (component accordion)",
   render: () => drawerOver(SAMPLE_STAMP_DETAILS.Civic),
   parameters: {
     docs: {
       description: {
         story:
-          "Civic scores across three real sub-credentials (Captcha 0.82, Uniqueness 5.0, Liveness 3.04, summing to 8.86), so the list paginates with dots and arrows. There is no scrollbar (an absolute SOP rule). The how-it-computes bar and the bottom-pinned action stay fixed while the component rows page.",
+          "Civic scores across three real sub-credentials (Captcha 0.82, Uniqueness 5.0, Liveness 3.04, summing to 8.86). They live in a Score breakdown accordion that opens by default, so all three rows are reachable and readable at once, none clipped. Each component's points show once on its row; the total (8.86) shows once in the header, so the redundant 'how your points add up = 8.86' caption is gone and the weighted bar carries no number. There is no scrollbar (an absolute SOP rule); if a stamp ever had more than a page of components the accordion paginates. The bottom-pinned action stays fixed.",
       },
     },
   },

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -78,6 +78,19 @@ export const VerifiedMinted: Story = {
   },
 };
 
+export const OnchainCredential: Story = {
+  name: "Stamp detail / Onchain credential (Human ID SBT)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.HumanIdKyc, { onRenew: noop, defaultOnchainOpen: true }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Government ID SBT with its Onchain credential block expanded. This block appears only on the four Human ID SBT stamps (Government ID, Biometrics, Phone, Proof of Clean Hands) and shows non-PII metadata only: issued date, expiry, chain (Optimism), revocation status, credential type, issuer (Human ID), and a View on chain link (the HubV3 contract on Optimism for the SBTs, the Sign Protocol attestation for Proof of Clean Hands). It never surfaces the nullifier or any personal field, and there is no fake token id. The block is collapsible so it always fits the fixed drawer height without scrolling.",
+      },
+    },
+  },
+};
+
 export const MintableReward: Story = {
   name: "Stamp detail / Biometrics (Notarize stamp)",
   render: () => drawerOver(SAMPLE_STAMP_DETAILS.Biometrics),

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -72,7 +72,7 @@ export const VerifiedMinted: Story = {
     docs: {
       description: {
         story:
-          "The Government ID SBT: verified and minted on chain. The header medallion drops its own chip and pip, so points and on-chain state are each stated once (the total points text and the emerald Minted pill). The whole-stamp expiry line reads 'Valid for N days', and because this is a Human ID SBT it adds the auto-renew note. The minted state resolves to View on chain, with a quiet Renew beneath it.",
+          "The Government ID SBT: verified and minted on chain. The header medallion drops its own chip and pip, so points and on-chain state are each stated once (the total points text and the emerald Minted pill). A small clock sits beside them; its tooltip carries the whole-stamp validity ('Valid for N days') plus, because this is a Human ID SBT, the auto renew note. The minted state resolves to View on chain, with a quiet Renew beside it.",
       },
     },
   },
@@ -85,7 +85,7 @@ export const MintableReward: Story = {
     docs: {
       description: {
         story:
-          "The Biometrics SBT: verified and mintable on chain. The status pill is gold (Mintable) and the bottom-pinned action is the gold Notarize stamp CTA (notarizing takes the stamp on chain). One primary action, so nothing competes with it. The Human ID auto-renew note rides beside the expiry line.",
+          "The Biometrics SBT: verified and mintable on chain. The status pill is an emerald outline (Mintable, never gold) and the bottom-pinned action is the emerald Notarize stamp CTA (notarizing takes the stamp on chain). One primary action, so nothing competes with it. The header stays clean: the validity and Human ID auto renew copy live behind the small clock's tooltip.",
       },
     },
   },
@@ -111,7 +111,7 @@ export const CleanHands: Story = {
     docs: {
       description: {
         story:
-          "The Proof of Clean Hands SBT. A verified, mintable credential awarded after identity verification and sanctions validation. The plain description avoids crypto jargon, the expiry line carries the Human ID auto-renew note, and the action is the gold Notarize stamp so the user can put the SBT on chain.",
+          "The Proof of Clean Hands SBT. A verified, mintable credential awarded after identity verification and sanctions validation. The plain description reads in full (with a more toggle when it runs long), the header clock's tooltip carries the validity and Human ID auto renew copy, and the action is the emerald Notarize stamp so the user can put the SBT on chain.",
       },
     },
   },
@@ -137,7 +137,7 @@ export const ExpiredStamp: Story = {
     docs: {
       description: {
         story:
-          "An expired stamp. The header medallion desaturates and the expiry line reads Expired in warn color. A quiet Renew action sits beside the primary so the lapsed credential can be refreshed.",
+          "An expired stamp. The header medallion desaturates with a muted outline and the clock reads muted (never amber, since amber is reserved for expiring); its tooltip says the stamp has expired. A quiet Renew action sits beside the primary so the lapsed credential can be refreshed.",
       },
     },
   },

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -3,23 +3,17 @@ import React, { useState } from "react";
 import { StampDetailDrawer } from "./StampDetailDrawer";
 import { StampsWindow } from "./StampsWindow";
 import { PassportShell } from "./PassportShell";
-import {
-  ThemePair,
-  SAMPLE_ACCOUNT,
-  SAMPLE_MEDALLION_STAMPS,
-  SAMPLE_STAMP_DETAILS,
-} from "./storyFrame";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS, SAMPLE_STAMP_DETAILS } from "./storyFrame";
 
 /**
  * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
  * window (modeled on app.passport.xyz's stamp drawer). A scrim dims and blurs the
  * grid behind; the drawer slides up as a solid glass sheet with a drag handle.
- * Header: medallion + name + total points + on-chain status pill. Then the
- * sub-credential rows (each with its own points + verified / expiry + icon),
- * paginated never scrolled. Then how the score is computed (the weighted
- * components summing to the total). Then one bottom-pinned state-driven action
- * (Mint / Claim / View on chain / Verified). Both themes, no network, everything
- * inside the shell.
+ * Header: real medallion icon + name + total points + on-chain status pill, plus
+ * whole-stamp expiry ("Valid for N days" / "Expires {date}" / "Expired"). Then the
+ * real sub-credential rows, paginated never scrolled. Then how the score is
+ * computed. Then one bottom-pinned state-driven action (Notarize stamp / Claim /
+ * View on chain / Verified). Both themes, no network, everything inside the shell.
  */
 const meta: Meta<typeof StampDetailDrawer> = {
   title: "Redesign/Stamp Detail",
@@ -48,15 +42,16 @@ const Stage: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 const noop = () => undefined;
 
-/** Compose a static Stamps window behind an open drawer, in both themes. */
+/** Compose a static Stamps window behind an open drawer, in both themes. The shell
+ *  carries the persistent compact score so it shows on the detail view too. */
 const drawerOver = (
   detail: (typeof SAMPLE_STAMP_DETAILS)[string],
   props: Partial<React.ComponentProps<typeof StampDetailDrawer>> = {}
 ) => (
   <ThemePair>
-    <PassportShell account={SAMPLE_ACCOUNT}>
+    <PassportShell account={SAMPLE_ACCOUNT} score={24} threshold={20} onScoreClick={noop}>
       <Stage>
-        <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} pageSize={6} onSelectStamp={noop} onVerify={noop} />
+        <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onSelectStamp={noop} onVerify={noop} />
         <StampDetailDrawer
           stamp={detail}
           onClose={noop}
@@ -71,65 +66,78 @@ const drawerOver = (
 );
 
 export const VerifiedMinted: Story = {
-  name: "Stamp detail / Verified and minted",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS["gov-id"], { onRenew: noop }),
+  name: "Stamp detail / Government ID (verified and minted)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.HumanIdKyc, { onRenew: noop }),
   parameters: {
     docs: {
       description: {
         story:
-          "A verified, minted stamp. The header medallion drops its own chip and pip, so the points and the on-chain state are each stated once (the total points text and the emerald Minted pill). Three verified components list with their points and renewal, and the weighted bar shows them summing to the total. The minted state resolves to a View on chain action, with a quiet Renew beneath it since a component renews.",
+          "The Government ID SBT: verified and minted on chain. The header medallion drops its own chip and pip, so points and on-chain state are each stated once (the total points text and the emerald Minted pill). The whole-stamp expiry line reads 'Valid for N days', and because this is a Human ID SBT it adds the auto-renew note. The minted state resolves to View on chain, with a quiet Renew beneath it.",
       },
     },
   },
 };
 
 export const MintableReward: Story = {
-  name: "Stamp detail / Mintable (Mint reward)",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS["biometric"]),
+  name: "Stamp detail / Biometrics (Notarize stamp)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.Biometrics),
   parameters: {
     docs: {
       description: {
         story:
-          "A verified stamp that can be minted on chain. The status pill is gold (Mintable) and the bottom-pinned action is the gold Mint reward CTA. One primary action, so no secondary competes with the reward.",
+          "The Biometrics SBT: verified and mintable on chain. The status pill is gold (Mintable) and the bottom-pinned action is the gold Notarize stamp CTA (notarizing takes the stamp on chain). One primary action, so nothing competes with it. The Human ID auto-renew note rides beside the expiry line.",
       },
     },
   },
 };
 
 export const Unverified: Story = {
-  name: "Stamp detail / Unverified (Claim)",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS["phone"]),
+  name: "Stamp detail / Coinbase (unverified, Claim)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.Coinbase),
   parameters: {
     docs: {
       description: {
         story:
-          "An unverified stamp. Its components read as not verified yet, the header shows zero points earned so far, and the how-it-computes bar is omitted because nothing is earned. The action resolves to Claim, so the state is never a dead end.",
+          "An unverified stamp. Its component reads as not verified yet, the header shows zero points earned so far, and the how-it-computes bar is omitted because nothing is earned. There is no expiry line (nothing is verified). The action resolves to Claim, so the state is never a dead end.",
       },
     },
   },
 };
 
 export const CleanHands: Story = {
-  name: "Stamp detail / Clean Hands SBT",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS["clean-hands"]),
+  name: "Stamp detail / Proof of Clean Hands SBT",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.CleanHands),
   parameters: {
     docs: {
       description: {
         story:
-          "The Proof of Clean Hands SBT (journeys 2 and 5). A verified, mintable credential proving a wallet is clear of sanctions and watchlists. The plain description avoids crypto jargon, and the action is the gold Mint reward so the user can put the SBT on chain.",
+          "The Proof of Clean Hands SBT. A verified, mintable credential awarded after identity verification and sanctions validation. The plain description avoids crypto jargon, the expiry line carries the Human ID auto-renew note, and the action is the gold Notarize stamp so the user can put the SBT on chain.",
       },
     },
   },
 };
 
 export const PaginatedComponents: Story = {
-  name: "Stamp detail / Paginated components",
-  render: () => drawerOver(SAMPLE_STAMP_DETAILS["reputation"]),
+  name: "Stamp detail / Civic (paginated components)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.Civic),
   parameters: {
     docs: {
       description: {
         story:
-          "Six components spill past one page, so the list paginates with dots and arrows. There is no scrollbar (an absolute SOP rule). The how-it-computes bar and the bottom-pinned action stay fixed while the component rows page, since the total is the same whichever page is shown.",
+          "Civic scores across three real sub-credentials (Captcha 0.82, Uniqueness 5.0, Liveness 3.04, summing to 8.86), so the list paginates with dots and arrows. There is no scrollbar (an absolute SOP rule). The how-it-computes bar and the bottom-pinned action stay fixed while the component rows page.",
+      },
+    },
+  },
+};
+
+export const ExpiredStamp: Story = {
+  name: "Stamp detail / NFT (expired)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS.NFT, { onRenew: noop }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An expired stamp. The header medallion desaturates and the expiry line reads Expired in warn color. A quiet Renew action sits beside the primary so the lapsed credential can be refreshed.",
       },
     },
   },
@@ -141,12 +149,7 @@ const InteractiveStage: React.FC = () => {
   const detail = openId ? SAMPLE_STAMP_DETAILS[openId] : undefined;
   return (
     <Stage>
-      <StampsWindow
-        stamps={SAMPLE_MEDALLION_STAMPS}
-        pageSize={6}
-        onSelectStamp={setOpenId}
-        onVerify={noop}
-      />
+      <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onSelectStamp={setOpenId} onVerify={noop} />
       {detail ? (
         <StampDetailDrawer
           stamp={detail}
@@ -165,7 +168,7 @@ export const Interactive: Story = {
   name: "Stamp detail / Interactive (tap a medallion)",
   render: () => (
     <ThemePair>
-      <PassportShell account={SAMPLE_ACCOUNT}>
+      <PassportShell account={SAMPLE_ACCOUNT} score={24} threshold={20} onScoreClick={noop}>
         <InteractiveStage />
       </PassportShell>
     </ThemePair>
@@ -174,7 +177,7 @@ export const Interactive: Story = {
     docs: {
       description: {
         story:
-          "Tap any medallion in the Stamps window to slide its detail drawer in over the grid. The scrim dims and blurs the grid behind; tap the scrim, the drag handle, the back arrow, or press Escape to close. Each stamp resolves to its own action: minted stamps view on chain, mintable stamps mint the reward, off-chain verified stamps show Verified, and unverified stamps claim.",
+          "Switch category, then tap any medallion to slide its detail drawer in over the grid. The scrim dims and blurs the grid behind; tap the scrim, the drag handle, the back arrow, or press Escape to close. Each stamp resolves to its own action: minted stamps view on chain, mintable stamps notarize, off-chain verified stamps show Verified, and unverified stamps claim.",
       },
     },
   },

--- a/src/redesign/StampDetailDrawer.stories.tsx
+++ b/src/redesign/StampDetailDrawer.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { StampDetailDrawer } from "./StampDetailDrawer";
+import { StampsWindow } from "./StampsWindow";
+import { PassportShell } from "./PassportShell";
+import {
+  ThemePair,
+  SAMPLE_ACCOUNT,
+  SAMPLE_MEDALLION_STAMPS,
+  SAMPLE_STAMP_DETAILS,
+} from "./storyFrame";
+
+/**
+ * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
+ * window (modeled on app.passport.xyz's stamp drawer). A scrim dims and blurs the
+ * grid behind; the drawer slides up as a solid glass sheet with a drag handle.
+ * Header: medallion + name + total points + on-chain status pill. Then the
+ * sub-credential rows (each with its own points + verified / expiry + icon),
+ * paginated never scrolled. Then how the score is computed (the weighted
+ * components summing to the total). Then one bottom-pinned state-driven action
+ * (Mint / Claim / View on chain / Verified). Both themes, no network, everything
+ * inside the shell.
+ */
+const meta: Meta<typeof StampDetailDrawer> = {
+  title: "Redesign/Stamp Detail",
+  component: StampDetailDrawer,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof StampDetailDrawer>;
+
+// The stage fills the shell content region and positions the drawer overlay, so
+// the drawer slides in over the Stamps window and stays inside the shell bounds.
+const Stage: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div
+    style={{
+      position: "relative",
+      flex: "1 1 auto",
+      minHeight: 0,
+      width: "100%",
+      display: "flex",
+      flexDirection: "column",
+    }}
+  >
+    {children}
+  </div>
+);
+
+const noop = () => undefined;
+
+/** Compose a static Stamps window behind an open drawer, in both themes. */
+const drawerOver = (
+  detail: (typeof SAMPLE_STAMP_DETAILS)[string],
+  props: Partial<React.ComponentProps<typeof StampDetailDrawer>> = {}
+) => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT}>
+      <Stage>
+        <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} pageSize={6} onSelectStamp={noop} onVerify={noop} />
+        <StampDetailDrawer
+          stamp={detail}
+          onClose={noop}
+          onMint={noop}
+          onClaim={noop}
+          onViewOnchain={noop}
+          {...props}
+        />
+      </Stage>
+    </PassportShell>
+  </ThemePair>
+);
+
+export const VerifiedMinted: Story = {
+  name: "Stamp detail / Verified and minted",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["gov-id"], { onRenew: noop }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A verified, minted stamp. The header medallion drops its own chip and pip, so the points and the on-chain state are each stated once (the total points text and the emerald Minted pill). Three verified components list with their points and renewal, and the weighted bar shows them summing to the total. The minted state resolves to a View on chain action, with a quiet Renew beneath it since a component renews.",
+      },
+    },
+  },
+};
+
+export const MintableReward: Story = {
+  name: "Stamp detail / Mintable (Mint reward)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["biometric"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A verified stamp that can be minted on chain. The status pill is gold (Mintable) and the bottom-pinned action is the gold Mint reward CTA. One primary action, so no secondary competes with the reward.",
+      },
+    },
+  },
+};
+
+export const Unverified: Story = {
+  name: "Stamp detail / Unverified (Claim)",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["phone"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An unverified stamp. Its components read as not verified yet, the header shows zero points earned so far, and the how-it-computes bar is omitted because nothing is earned. The action resolves to Claim, so the state is never a dead end.",
+      },
+    },
+  },
+};
+
+export const CleanHands: Story = {
+  name: "Stamp detail / Clean Hands SBT",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["clean-hands"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Proof of Clean Hands SBT (journeys 2 and 5). A verified, mintable credential proving a wallet is clear of sanctions and watchlists. The plain description avoids crypto jargon, and the action is the gold Mint reward so the user can put the SBT on chain.",
+      },
+    },
+  },
+};
+
+export const PaginatedComponents: Story = {
+  name: "Stamp detail / Paginated components",
+  render: () => drawerOver(SAMPLE_STAMP_DETAILS["reputation"]),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Six components spill past one page, so the list paginates with dots and arrows. There is no scrollbar (an absolute SOP rule). The how-it-computes bar and the bottom-pinned action stay fixed while the component rows page, since the total is the same whichever page is shown.",
+      },
+    },
+  },
+};
+
+// ---- interactive: tap a medallion in the Stamps window to open its drawer ----
+const InteractiveStage: React.FC = () => {
+  const [openId, setOpenId] = useState<string | null>(null);
+  const detail = openId ? SAMPLE_STAMP_DETAILS[openId] : undefined;
+  return (
+    <Stage>
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        pageSize={6}
+        onSelectStamp={setOpenId}
+        onVerify={noop}
+      />
+      {detail ? (
+        <StampDetailDrawer
+          stamp={detail}
+          onClose={() => setOpenId(null)}
+          onMint={noop}
+          onClaim={noop}
+          onViewOnchain={noop}
+          onRenew={noop}
+        />
+      ) : null}
+    </Stage>
+  );
+};
+
+export const Interactive: Story = {
+  name: "Stamp detail / Interactive (tap a medallion)",
+  render: () => (
+    <ThemePair>
+      <PassportShell account={SAMPLE_ACCOUNT}>
+        <InteractiveStage />
+      </PassportShell>
+    </ThemePair>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Tap any medallion in the Stamps window to slide its detail drawer in over the grid. The scrim dims and blurs the grid behind; tap the scrim, the drag handle, the back arrow, or press Escape to close. Each stamp resolves to its own action: minted stamps view on chain, mintable stamps mint the reward, off-chain verified stamps show Verified, and unverified stamps claim.",
+      },
+    },
+  },
+};

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -11,11 +11,10 @@ import {
   LinkIcon,
   PlusIcon,
   RetryIcon,
-  StarIcon,
 } from "./icons";
 import { deriveTints } from "./deriveTints";
 import { formatExpiry } from "./expiry";
-import { useAccentRgb, useReducedMotion } from "./hooks";
+import { useAccentRgb } from "./hooks";
 import type { ShellSize } from "./PassportShell";
 
 /**
@@ -34,8 +33,22 @@ export type StampComponent = {
    * "Expired". Kept plain, no crypto jargon, no dashes. Omit when not relevant.
    */
   expiry?: string;
-  /** Optional row icon (an emoji, an <img>, or an icon node). */
+  /** Optional row icon (an emoji, an <img>, or an icon node). Omit for no icon. */
   icon?: React.ReactNode;
+  /**
+   * TODO(sbt-metadata): the in-progress research pass is sourcing the real SBT
+   * fields for each component (issued date, on-chain SBT id, chain). They render
+   * as a quiet sub-line under the component name when present; until the data
+   * lands this stays undefined so nothing shows. Drop the values in here.
+   */
+  sbt?: {
+    /** Human date the credential was issued, e.g. "Issued Apr 12". */
+    issued?: string;
+    /** Short SBT token id, e.g. "#4821". */
+    sbtId?: string;
+    /** Chain the SBT lives on, e.g. "Optimism". */
+    chain?: string;
+  };
 };
 
 /**
@@ -46,8 +59,8 @@ export type StampComponent = {
 export type StampDetail = Stamp & {
   /** The components / sub-credentials that were used to score this stamp. */
   components: StampComponent[];
-  /** Optional plain one-line description of what the stamp proves. */
-  description?: string;
+  /* `description` is inherited from Stamp (surfaced as the grid tooltip and the
+     drawer's own description line). */
 };
 
 /** The bottom-pinned action the drawer resolves to. One primary action. */
@@ -129,15 +142,26 @@ const paginate = <T,>(items: T[], per: number): T[][] => {
   return pages.length ? pages : [[]];
 };
 
-/** One sub-credential row: icon + name + verified / expiry line + points chip. */
+/**
+ * One sub-credential row: [meaningful icon, if any] + name + verified / expiry
+ * state + points chip. No filler icon: when a component has no real icon the row
+ * simply leads with the name (the old placeholder star was meaningless). An
+ * optional SBT metadata sub-line (issued / id / chain) shows when present.
+ */
 const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) => {
-  const { name, points, verified, expiry, icon } = component;
+  const { name, points, verified, expiry, icon, sbt } = component;
   const state = verified ? (expiry ? expiry : "Verified") : "Not verified yet";
+  // SBT slot: joined into one quiet line, only for the parts that are present.
+  const sbtLine = sbt
+    ? [sbt.issued, sbt.sbtId, sbt.chain].filter(Boolean).join("  ·  ")
+    : "";
   return (
     <div className={styles.row} data-verified={verified ? "true" : "false"}>
-      <span className={styles.rowIcon} aria-hidden="true">
-        {icon ?? <StarIcon size={15} strokeWidth={1.6} />}
-      </span>
+      {icon ? (
+        <span className={styles.rowIcon} aria-hidden="true">
+          {icon}
+        </span>
+      ) : null}
       <span className={styles.rowMeta}>
         <span className={styles.rowName}>{name}</span>
         <span className={styles.rowState}>
@@ -150,6 +174,7 @@ const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) =>
           ) : null}
           {state}
         </span>
+        {sbtLine ? <span className={styles.rowSbt}>{sbtLine}</span> : null}
       </span>
       <span className={styles.rowPoints}>+{points}</span>
     </div>
@@ -227,9 +252,20 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
   statusTooltip,
 }) => {
   const rootRef = useRef<HTMLDivElement>(null);
-  const reduced = useReducedMotion();
   const accent = useAccentRgb(rootRef);
   const [page, setPage] = useState(0);
+
+  // Description: clamped to two lines by default, with an inline "more" toggle so
+  // the full text is always reachable (no dead-end truncation). "more" only shows
+  // when the text actually overflows the clamp, measured after render.
+  const descRef = useRef<HTMLParagraphElement>(null);
+  const [descOpen, setDescOpen] = useState(false);
+  const [descClamped, setDescClamped] = useState(false);
+  useEffect(() => {
+    setDescOpen(false);
+    const el = descRef.current;
+    if (el) setDescClamped(el.scrollHeight - el.clientHeight > 2);
+  }, [stamp.description, stamp.id]);
 
   // Escape closes the drawer while it is open.
   useEffect(() => {
@@ -272,9 +308,20 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
   const action = deriveAction(stamp, actionState);
   const showRenew = Boolean(onRenew) && stamp.verified && action !== "claim";
 
-  // Every stamp expires as a whole. The header states it in full ("Valid for N
-  // days" / "Expires {date}" / "Expired"); Human ID SBTs add the auto-renew note.
+  // Every stamp expires as a whole. Rather than a long line at the top, the
+  // validity / renewal copy now lives in the header timer's tooltip. Human ID
+  // SBTs add the auto renew note.
   const expiry = formatExpiry(stamp.expirationDate);
+  const renewNote = stamp.isHumanId
+    ? " Auto renews after 90 days, full reverification after a year."
+    : "";
+  const expiryLead = expiry
+    ? expiry.state === "expired"
+      ? "This stamp has expired."
+      : `${expiry.long}.`
+    : "";
+  const expiryTip = expiry ? `${expiryLead}${renewNote}` : null;
+  const expiryAria = expiry ? `Validity. ${expiryLead}${renewNote}` : "";
 
   const compact = size !== "full";
   const medallionPx = compact ? 40 : 46;
@@ -325,7 +372,9 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
         </div>
 
         {/* Header: clean medallion (no chip / pip, so points + on-chain are stated
-            once, below) + name + total points + on-chain status pill. */}
+            once, below) + name + total points + on-chain status pill + a small
+            timer whose tooltip carries the whole-stamp validity / renewal copy, so
+            the long validity line no longer crowds the top. */}
         <header className={styles.header}>
           <Medallion stamp={stamp} showPoints={false} showPip={false} sizePx={medallionPx} />
           <div className={styles.headMeta}>
@@ -348,28 +397,38 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
                 </span>
               </Tooltip>
               <span className={styles.headPoints}>{earned} points</span>
+              {expiry ? (
+                <Tooltip content={expiryTip} placement="top" className={glass.tip}>
+                  <span
+                    className={styles.timer}
+                    data-state={expiry.state}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={expiryAria}
+                  >
+                    <ClockIcon size={14} strokeWidth={1.9} />
+                  </span>
+                </Tooltip>
+              ) : null}
             </div>
           </div>
         </header>
 
-        {stamp.description ? <p className={styles.desc}>{stamp.description}</p> : null}
-
-        {/* Expiry: a stamp expires as a whole. Amber when expiring soon, warn when
-            expired. Human ID SBTs carry the auto-renew note beside it. */}
-        {expiry ? (
-          <div className={styles.expiry} data-state={expiry.state}>
-            <span className={styles.expiryIcon} aria-hidden="true">
-              <ClockIcon size={13} strokeWidth={1.9} />
-            </span>
-            <span className={styles.expiryText}>
-              {expiry.long}
-              {stamp.isHumanId ? (
-                <span className={styles.expiryNote}>
-                  {" "}
-                  Auto renews after 90 days, full reverification after a year.
-                </span>
-              ) : null}
-            </span>
+        {stamp.description ? (
+          <div className={styles.descWrap}>
+            <p ref={descRef} className={`${styles.desc} ${descOpen ? styles.descOpen : ""}`}>
+              {stamp.description}
+            </p>
+            {descClamped ? (
+              <button
+                type="button"
+                className={styles.moreBtn}
+                onClick={() => setDescOpen((v) => !v)}
+                aria-expanded={descOpen}
+              >
+                {descOpen ? "less" : "more"}
+              </button>
+            ) : null}
           </div>
         ) : null}
 
@@ -414,9 +473,11 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
             the two-action case reserves no extra height inside the fixed shell. */}
         <div className={`${styles.actions} ${showRenew ? styles.actionsRow : ""}`}>
           {action === "mint" ? (
-            <button type="button" className={`${styles.cta} ${styles.ctaReward}`} onClick={onMint}>
+            /* Notarize = anchor the stamp on chain. Emerald primary (never gold),
+               with the chain-link glyph. */
+            <button type="button" className={styles.cta} onClick={onMint}>
               <span className={styles.ctaIcon}>
-                <StarIcon size={15} strokeWidth={1.9} />
+                <LinkIcon size={15} strokeWidth={1.9} />
               </span>
               <span className={styles.ctaLabel}>{mintLabel ?? "Notarize stamp"}</span>
             </button>

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -1,0 +1,439 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./StampDetailDrawer.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
+import { Medallion, type Stamp, type StampOnchain } from "./StampsWindow";
+import {
+  ArrowLeftIcon,
+  CaretDownIcon,
+  CheckIcon,
+  ClockIcon,
+  LinkIcon,
+  PlusIcon,
+  RetryIcon,
+  StarIcon,
+} from "./icons";
+import { deriveTints } from "./deriveTints";
+import { useAccentRgb, useReducedMotion } from "./hooks";
+import type { ShellSize } from "./PassportShell";
+
+/**
+ * One sub-credential that contributes to a stamp's score. Each is a row in the
+ * drawer with its own points, verified / expiry state, and an icon.
+ */
+export type StampComponent = {
+  /** Short component name, e.g. "Government ID number" or "Liveness check". */
+  name: string;
+  /** Points this component contributes to the stamp's total. */
+  points: number;
+  /** Whether this component is verified (earned) or still missing. */
+  verified: boolean;
+  /**
+   * Plain expiry / renewal line for a verified component, e.g. "Renews Aug 3" or
+   * "Expired". Kept plain, no crypto jargon, no dashes. Omit when not relevant.
+   */
+  expiry?: string;
+  /** Optional row icon (an emoji, an <img>, or an icon node). */
+  icon?: React.ReactNode;
+};
+
+/**
+ * A stamp with the detail-drawer payload: the components used to score it and an
+ * optional plain description. Extends the Stamps window `Stamp` so the same id /
+ * name / points / verified / onchain / icon carry through.
+ */
+export type StampDetail = Stamp & {
+  /** The components / sub-credentials that were used to score this stamp. */
+  components: StampComponent[];
+  /** Optional plain one-line description of what the stamp proves. */
+  description?: string;
+};
+
+/** The bottom-pinned action the drawer resolves to. One primary action. */
+export type StampAction = "mint" | "claim" | "view" | "verified";
+
+export type StampDetailDrawerProps = {
+  /** The stamp being detailed (header + components + action derive from it). */
+  stamp: StampDetail;
+  /**
+   * Whether the drawer is shown. Default true. When false the overlay stays
+   * mounted but slides down and fades out (pointer-events off), so a parent can
+   * animate it closed instead of unmounting. Consumers may also just conditionally
+   * mount it; the enter animation plays either way.
+   */
+  open?: boolean;
+  /**
+   * Size variant, mirrors the shell's, used only to tune density (components per
+   * page + medallion size). The drawer always fills its container. Default full.
+   */
+  size?: ShellSize;
+  /** Components shown per page before the list paginates (never scrolls). */
+  componentsPerPage?: number;
+
+  /** Close the drawer (scrim tap, drag handle, close button, Escape). */
+  onClose?: () => void;
+  /** Mint the stamp on-chain (the gold reward action when mintable). */
+  onMint?: () => void;
+  /** Claim / verify the stamp (unverified). */
+  onClaim?: () => void;
+  /** View the minted stamp on-chain. */
+  onViewOnchain?: () => void;
+  /** Renew an expiring credential. Shown as a quiet secondary when provided. */
+  onRenew?: () => void;
+
+  /** Force the primary action state, overriding the derived one. */
+  actionState?: StampAction;
+  /** Label overrides for each action (dev-overridable copy). */
+  mintLabel?: string;
+  claimLabel?: string;
+  viewOnchainLabel?: string;
+  verifiedLabel?: string;
+  renewLabel?: string;
+
+  /** Override the on-chain status pill's glass tooltip copy. */
+  statusTooltip?: React.ReactNode;
+};
+
+const ONCHAIN_PILL: Record<StampOnchain, string> = {
+  minted: "Minted",
+  mintable: "Mintable",
+  none: "Off chain",
+};
+
+const ONCHAIN_TIP: Record<StampOnchain, string> = {
+  minted: "This stamp is recorded on chain.",
+  mintable: "You can mint this stamp on chain to earn the reward.",
+  none: "This stamp lives off chain. Nothing is written on chain.",
+};
+
+// Conservative so a page's rows always fit the fixed shell height alongside the
+// header, the how-computed bar, and the bottom-pinned action, with the rest of
+// the components moving to the next page (paginate, never scroll).
+const DEFAULT_PER_PAGE: Record<ShellSize, number> = { full: 2, mini: 2, pill: 2 };
+
+/** Derive the single primary action from the stamp state (dev-overridable). */
+const deriveAction = (stamp: StampDetail, override?: StampAction): StampAction => {
+  if (override) return override;
+  if (!stamp.verified) return "claim";
+  if (stamp.onchain === "mintable") return "mint";
+  if (stamp.onchain === "minted") return "view";
+  return "verified";
+};
+
+/** Split a flat list into fixed-size pages (mirrors the Stamps window pager). */
+const paginate = <T,>(items: T[], per: number): T[][] => {
+  if (per <= 0) return [items];
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += per) pages.push(items.slice(i, i + per));
+  return pages.length ? pages : [[]];
+};
+
+/** One sub-credential row: icon + name + verified / expiry line + points chip. */
+const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) => {
+  const { name, points, verified, expiry, icon } = component;
+  const state = verified ? (expiry ? expiry : "Verified") : "Not verified yet";
+  return (
+    <div className={styles.row} data-verified={verified ? "true" : "false"}>
+      <span className={styles.rowIcon} aria-hidden="true">
+        {icon ?? <StarIcon size={15} strokeWidth={1.6} />}
+      </span>
+      <span className={styles.rowMeta}>
+        <span className={styles.rowName}>{name}</span>
+        <span className={styles.rowState}>
+          {verified ? (
+            expiry ? (
+              <ClockIcon size={11} strokeWidth={1.9} />
+            ) : (
+              <CheckIcon size={11} strokeWidth={2.2} />
+            )
+          ) : null}
+          {state}
+        </span>
+      </span>
+      <span className={styles.rowPoints}>+{points}</span>
+    </div>
+  );
+};
+
+/** Reused pager: dots + arrows, never a scrollbar (matches the Stamps window). */
+const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => void }> = ({
+  page,
+  pageCount,
+  onPage,
+}) => (
+  <div className={styles.pager} role="group" aria-label="Component pages">
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.max(0, page - 1))}
+      disabled={page === 0}
+      aria-label="Previous components"
+    >
+      <CaretDownIcon className={styles.pagerPrev} size={13} />
+    </button>
+    <span className={styles.pagerDots}>
+      {Array.from({ length: pageCount }).map((_, i) => (
+        <button
+          type="button"
+          key={i}
+          className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+          onClick={() => onPage(i)}
+          aria-label={`Component page ${i + 1}`}
+          aria-current={i === page ? "true" : undefined}
+        />
+      ))}
+    </span>
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.min(pageCount - 1, page + 1))}
+      disabled={page === pageCount - 1}
+      aria-label="More components"
+    >
+      <CaretDownIcon className={styles.pagerNext} size={13} />
+    </button>
+  </div>
+);
+
+/**
+ * StampDetailDrawer - a passport-style slide-in drawer that opens OVER the Stamps
+ * window (SOP §4, modeled on app.passport.xyz's stamp drawer). A scrim dims and
+ * blurs the grid behind; the drawer slides up from the bottom as a solid glass
+ * sheet with a drag handle. Header carries the medallion + name + total points +
+ * on-chain status pill; then the sub-credential rows (each with its own points +
+ * verified / expiry + icon), paginated never scrolled; then how the score is
+ * computed (the weighted components summing to the total); then one bottom-pinned
+ * state-driven action (Mint / Claim / View on chain / Verified) plus an optional
+ * renew. Presentational: props only, both-theme legible, reduced-motion aware,
+ * everything inside the shell.
+ */
+export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
+  stamp,
+  open = true,
+  size = "full",
+  componentsPerPage,
+  onClose,
+  onMint,
+  onClaim,
+  onViewOnchain,
+  onRenew,
+  actionState,
+  mintLabel,
+  claimLabel,
+  viewOnchainLabel,
+  verifiedLabel,
+  renewLabel,
+  statusTooltip,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const accent = useAccentRgb(rootRef);
+  const [page, setPage] = useState(0);
+
+  // Escape closes the drawer while it is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const per = componentsPerPage ?? DEFAULT_PER_PAGE[size];
+  const pages = useMemo(() => paginate(stamp.components, per), [stamp.components, per]);
+  const pageCount = pages.length;
+  const current = Math.min(page, pageCount - 1);
+  const pageComponents = pages[current] ?? [];
+
+  // Earned total = sum of the verified components' points. This is the number the
+  // header states and the weighted bar sums to (one source, no hardcoded total).
+  const earned = useMemo(
+    () => stamp.components.reduce((a, c) => a + (c.verified ? c.points : 0), 0),
+    [stamp.components]
+  );
+
+  // How the score is computed: the verified components as accent-derived segments
+  // whose LENGTH is each one's share of the total. One hue family, no rainbow, no
+  // legend (points ride on the rows above). Ranked so the largest reads deepest.
+  const segments = useMemo(() => {
+    const verified = stamp.components.filter((c) => c.verified && c.points > 0);
+    const denom = verified.reduce((a, c) => a + c.points, 0) || 1;
+    const ranked = verified.slice().sort((a, b) => b.points - a.points);
+    const tints = deriveTints(accent, verified.length);
+    return verified.map((c) => ({
+      name: c.name,
+      pct: (c.points / denom) * 100,
+      color: tints[Math.max(0, ranked.indexOf(c))],
+    }));
+  }, [stamp.components, accent]);
+
+  const action = deriveAction(stamp, actionState);
+  const showRenew = Boolean(onRenew) && stamp.verified && action !== "claim";
+
+  const compact = size !== "full";
+  const medallionPx = compact ? 40 : 46;
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.overlay}
+      data-open={open ? "true" : "false"}
+      role="dialog"
+      aria-modal="false"
+      aria-label={`${stamp.name} details`}
+    >
+      {/* Scrim: the ONE translucent layer. Dims + blurs the grid behind and closes
+          the drawer on tap. The drawer sheet on top is solid so content stays
+          legible (materials rule: never stack translucent layers to mush). */}
+      <button
+        type="button"
+        className={styles.scrim}
+        aria-label="Close stamp details"
+        tabIndex={open ? 0 : -1}
+        onClick={onClose}
+      />
+
+      <section className={styles.drawer}>
+        {/* Drag handle doubles as a close affordance; an explicit back button sits
+            beside it for keyboard users. */}
+        <div className={styles.handleRow}>
+          <button
+            type="button"
+            className={styles.back}
+            onClick={onClose}
+            tabIndex={open ? 0 : -1}
+            aria-label="Back to stamps"
+          >
+            <ArrowLeftIcon size={13} />
+          </button>
+          <button
+            type="button"
+            className={styles.handle}
+            onClick={onClose}
+            tabIndex={open ? 0 : -1}
+            aria-label="Close stamp details"
+          >
+            <span className={styles.handleBar} aria-hidden="true" />
+          </button>
+          <span className={styles.handleSpacer} aria-hidden="true" />
+        </div>
+
+        {/* Header: clean medallion (no chip / pip, so points + on-chain are stated
+            once, below) + name + total points + on-chain status pill. */}
+        <header className={styles.header}>
+          <Medallion stamp={stamp} showPoints={false} showPip={false} sizePx={medallionPx} />
+          <div className={styles.headMeta}>
+            <h3 className={styles.name}>{stamp.name}</h3>
+            <div className={styles.headSub}>
+              <Tooltip content={statusTooltip ?? ONCHAIN_TIP[stamp.onchain]} placement="top" className={glass.tip}>
+                <span
+                  className={styles.statusPill}
+                  data-onchain={stamp.onchain}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`${ONCHAIN_PILL[stamp.onchain]}. ${
+                    statusTooltip ? "" : ONCHAIN_TIP[stamp.onchain]
+                  }`}
+                >
+                  <span className={styles.statusDot} aria-hidden="true">
+                    {stamp.onchain === "none" ? null : <LinkIcon size={9} strokeWidth={2} />}
+                  </span>
+                  {ONCHAIN_PILL[stamp.onchain]}
+                </span>
+              </Tooltip>
+              <span className={styles.headPoints}>{earned} points</span>
+            </div>
+          </div>
+        </header>
+
+        {stamp.description ? <p className={styles.desc}>{stamp.description}</p> : null}
+
+        {/* Sub-credential rows, paginated (never scrolled). */}
+        <div className={styles.list}>
+          <p className={styles.srOnly} aria-live="polite">
+            {stamp.components.length} components. Page {current + 1} of {pageCount}.
+          </p>
+          {pageComponents.map((c, i) => (
+            <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
+          ))}
+        </div>
+
+        {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+
+        {/* How the score is computed: the weighted components summing to the total.
+            Length encodes each share; one accent family; the total on the right. */}
+        {segments.length ? (
+          <div className={styles.compute}>
+            <div className={styles.computeHead}>
+              <span className={styles.computeLabel}>How your points add up</span>
+              <span className={styles.computeTotal}>{earned} points</span>
+            </div>
+            <div
+              className={styles.computeBar}
+              role="img"
+              aria-label={`The verified components sum to ${earned} points.`}
+            >
+              {segments.map((seg, i) => (
+                <span
+                  key={`${seg.name}-${i}`}
+                  className={styles.computeSeg}
+                  style={{ width: `${seg.pct}%`, background: seg.color }}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {/* Action area: bottom-pinned, one primary action, state-driven. When a
+            renew is shown it sits BESIDE the primary on one row (not stacked), so
+            the two-action case reserves no extra height inside the fixed shell. */}
+        <div className={`${styles.actions} ${showRenew ? styles.actionsRow : ""}`}>
+          {action === "mint" ? (
+            <button type="button" className={`${styles.cta} ${styles.ctaReward}`} onClick={onMint}>
+              <span className={styles.ctaIcon}>
+                <StarIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{mintLabel ?? "Mint reward"}</span>
+            </button>
+          ) : action === "claim" ? (
+            <button type="button" className={styles.cta} onClick={onClaim}>
+              <span className={styles.ctaIcon}>
+                <PlusIcon size={15} strokeWidth={2} />
+              </span>
+              <span className={styles.ctaLabel}>{claimLabel ?? "Claim stamp"}</span>
+            </button>
+          ) : action === "view" ? (
+            <button type="button" className={styles.cta} onClick={onViewOnchain}>
+              <span className={styles.ctaIcon}>
+                <LinkIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{viewOnchainLabel ?? "View on chain"}</span>
+            </button>
+          ) : (
+            <div className={styles.doneRow}>
+              <span className={styles.doneSeal} aria-hidden="true">
+                <CheckIcon size={14} strokeWidth={2.6} />
+              </span>
+              <span className={styles.doneText}>{verifiedLabel ?? "Verified"}</span>
+            </div>
+          )}
+
+          {/* Renewal, where relevant. Quiet tonal secondary, never the primary. */}
+          {showRenew ? (
+            <button
+              type="button"
+              className={`${styles.cta} ${styles.ctaSecondary} ${styles.ctaRenew}`}
+              onClick={onRenew}
+            >
+              <span className={styles.ctaIcon}>
+                <RetryIcon size={15} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ctaLabel}>{renewLabel ?? "Renew"}</span>
+            </button>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -12,6 +12,7 @@ import {
   PlusIcon,
   RetryIcon,
 } from "./icons";
+import { OptimismIcon } from "./stampIcons";
 import { deriveTints } from "./deriveTints";
 import { formatExpiry } from "./expiry";
 import { useAccentRgb } from "./hooks";
@@ -55,21 +56,35 @@ export type StampDetail = Stamp & {
    * (getKycSBTByAddress / getPhoneSBTByAddress / getBiometricsSBTByAddress)
    * return { expiry, publicValues: [expiry, recipient, actionId, nullifier,
    * issuer], revoked }; Proof of Clean Hands returns a Sign Protocol attestation
-   * ({ attestTimestamp, validUntil, revoked, attestationId }). The embed already
-   * fetches these in useHumanIDVerification and discards them, so this block is
-   * purely presentational: seed it via props, render, done.
+   * ({ attestTimestamp, validUntil, revoked, attestationId, data }). The embed
+   * already fetches these in useHumanIDVerification and discards them, so this
+   * block is purely presentational: seed it via props, render, done.
+   *
+   * Unit gotcha for whoever wires the real getters: the SBT `expiry` and the
+   * attestation `validUntil` are UNIX SECONDS, while the attestation
+   * `attestTimestamp` is MILLISECONDS. Convert before formatting the strings
+   * passed in here.
    *
    * DELIBERATELY NOT SURFACED: name, DOB, document number, nationality, phone
-   * number, biometric data, the ABI `data` blob, and crucially the
-   * nullifier / indexingValue (a stable per-user correlation handle). Leaving the
-   * nullifier out is the privacy point, not an oversight. There is no ERC-721
-   * tokenId and no mint transaction in the SBT read path, so no "SBT #1234" id is
-   * shown; only Proof of Clean Hands has an attestation id / tx for its link.
+   * number, biometric data, the recipient/user address, and crucially the
+   * nullifier / indexingValue (a stable per-user correlation handle). For Proof
+   * of Clean Hands the attestation `data` is only a scope actionId with nothing
+   * to decode, there is NO observer and NO displayable signature, so none are
+   * invented here. Leaving all of this out is the privacy point, not an omission.
+   * There is no ERC-721 tokenId and no mint transaction in the SBT read path, so
+   * no "SBT #1234" id is shown.
    *
    * Named `onchainCredential` (not `onchain`) because `Stamp.onchain` already
    * carries the minted / mintable / none state string.
    */
   onchainCredential?: {
+    /**
+     * Which protocol backs the credential, so the block labels + view link are
+     * accurate: "sbt" = a Human ID SBT on Optimism (view on chain -> the HubV3
+     * contract); "sign" = a Sign Protocol attestation (Proof of Clean Hands;
+     * view -> scan.sign.global). NOT EAS.
+     */
+    protocol: "sbt" | "sign";
     /** Issue date, e.g. "Apr 12, 2026". Omit when unknown (never invented). */
     issued?: string;
     /** Expiry date, e.g. "Oct 17, 2026". Mirrors the header clock's validity. */
@@ -80,12 +95,23 @@ export type StampDetail = Stamp & {
     revoked: boolean;
     /** Credential type, e.g. "Government ID". */
     credential: string;
-    /** Issuing authority, e.g. "Human ID". */
+    /**
+     * Verified issuer DISPLAY name, e.g. "human.tech". Never a raw hex address:
+     * the issuer / attester address is a verified on-chain identity, so it reads
+     * as a name with a view-on-chain link, not a hex string.
+     */
     issuer: string;
     /**
-     * Explorer link: the HubV3 contract
-     * (0x2AA822e264F8cc31A2b9C22f39e5551241e94DfB) on Optimism for the SBTs, or
-     * the attestation for Proof of Clean Hands. Omit to drop the affordance.
+     * View-on-chain link for the verified issuer / attester: the HubV3 contract
+     * (0x2AA822e264F8cc31A2b9C22f39e5551241e94DfB) for SBTs, the Clean Hands
+     * attester (0xB1f50c6C34C72346b1229e5C80587D0D659556Fd) for Sign Protocol.
+     * Omit to render the issuer name without a link.
+     */
+    issuerUrl?: string;
+    /**
+     * View-the-credential link: the HubV3 contract on Optimism for the SBTs, or
+     * `https://scan.sign.global/attestation/${id}` (id like `onchain_evm_10_0x…`)
+     * for a Proof of Clean Hands attestation. Omit to drop the affordance.
      */
     explorerUrl?: string;
   };
@@ -114,7 +140,7 @@ export type StampDetailDrawerProps = {
 
   /** Close the drawer (scrim tap, drag handle, close button, Escape). */
   onClose?: () => void;
-  /** Mint the stamp on-chain (the gold reward action when mintable). */
+  /** Notarize the stamp on-chain (the emerald reward action when mintable, never gold). */
   onMint?: () => void;
   /** Claim / verify the stamp (unverified). */
   onClaim?: () => void;
@@ -135,10 +161,10 @@ export type StampDetailDrawerProps = {
   /** Override the on-chain status pill's glass tooltip copy. */
   statusTooltip?: React.ReactNode;
   /**
-   * Render the "Onchain credential" block expanded on first paint (Human ID SBT
-   * stamps only, and only when `stamp.onchainCredential` is supplied). Defaults
-   * to collapsed so the fixed drawer height is never at risk; open it to show the
-   * metadata rows.
+   * Render the "Onchain credential" accordion expanded on first paint (Human ID
+   * SBT / attestation stamps only, and only when `stamp.onchainCredential` is
+   * supplied). Defaults to collapsed so the fixed drawer height is never at risk;
+   * open it to show the metadata rows.
    */
   defaultOnchainOpen?: boolean;
 };
@@ -155,10 +181,10 @@ const ONCHAIN_TIP: Record<StampOnchain, string> = {
   none: "This stamp lives off chain. Nothing is written on chain.",
 };
 
-// Conservative so a page's rows always fit the fixed shell height alongside the
-// header, the how-computed bar, and the bottom-pinned action, with the rest of
-// the components moving to the next page (paginate, never scroll).
-const DEFAULT_PER_PAGE: Record<ShellSize, number> = { full: 2, mini: 2, pill: 2 };
+// Components fit within the expanded breakdown accordion, paginating (never
+// scrolling) only in the rare case a stamp carries more than a page of them. The
+// real multi-component stamps top out at three, so a page holds them all.
+const DEFAULT_PER_PAGE: Record<ShellSize, number> = { full: 4, mini: 3, pill: 3 };
 
 /** Derive the single primary action from the stamp state (dev-overridable). */
 const deriveAction = (stamp: StampDetail, override?: StampAction): StampAction => {
@@ -285,19 +311,29 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
   const accent = useAccentRgb(rootRef);
   const [page, setPage] = useState(0);
 
-  // Onchain credential block: collapsed by default so the fixed drawer height is
-  // never at risk. Reset when the stamp changes.
   const oc = stamp.onchainCredential;
-  const [ocOpen, setOcOpen] = useState(defaultOnchainOpen);
+  // A single-component stamp needs no breakdown: the header total already states
+  // its one contribution once (no restating the same number three ways). A
+  // multi-component stamp gets the "Score breakdown" accordion instead.
+  const isMulti = stamp.components.length > 1;
+
+  // The drawer body is an accordion GROUP: at most one section is open at a time,
+  // so an expanded section always fits the fixed drawer height (no clip, no
+  // scroll). A multi-component stamp opens "Score breakdown" by default so every
+  // component is immediately readable (Civic's three no longer clip); the taller
+  // "Onchain credential" block defaults collapsed, and only IT hides the
+  // description while open, to stay within the fixed height. Reset on stamp change.
+  type Section = "breakdown" | "onchain";
+  const initialSection = (): Section | null =>
+    isMulti ? "breakdown" : oc && defaultOnchainOpen ? "onchain" : null;
+  const [openSection, setOpenSection] = useState<Section | null>(initialSection);
   useEffect(() => {
-    setOcOpen(defaultOnchainOpen);
-  }, [stamp.id, defaultOnchainOpen]);
-  // When the onchain block is open it takes over the drawer's flexible middle:
-  // the component list, its pager, and the one-segment compute bar step aside so
-  // the full credential rows fit the fixed height with no truncation or scroll.
-  // Human ID SBT stamps carry a single component that just restates the header,
-  // so nothing meaningful is hidden. Everything returns when the block collapses.
-  const ocViewOpen = Boolean(oc && ocOpen);
+    setOpenSection(isMulti ? "breakdown" : oc && defaultOnchainOpen ? "onchain" : null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stamp.id, isMulti, defaultOnchainOpen]);
+  const breakdownOpen = openSection === "breakdown";
+  const onchainOpen = openSection === "onchain";
+  const toggleSection = (s: Section) => setOpenSection((prev) => (prev === s ? null : s));
 
   // Description: clamped to two lines by default, with an inline "more" toggle so
   // the full text is always reachable (no dead-end truncation). "more" only shows
@@ -458,7 +494,11 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
           </div>
         </header>
 
-        {stamp.description && !ocViewOpen ? (
+        {/* Description yields space when a section is expanded (the Shield
+            space-yielding-accordion pattern), so an open section always fits the
+            fixed drawer height with the action row bottom-pinned and never
+            clipped. Collapse a section to read the full description. */}
+        {stamp.description && openSection === null ? (
           <div className={styles.descWrap}>
             <p ref={descRef} className={`${styles.desc} ${descOpen ? styles.descOpen : ""}`}>
               {stamp.description}
@@ -476,86 +516,139 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
           </div>
         ) : null}
 
-        {/* Sub-credential rows, paginated (never scrolled). While the onchain block
-            is open this whole region (and the description + compute bar) steps
-            aside for a focused credential view, so nothing is clipped or scrolls. */}
-        {ocViewOpen ? null : (
-          <>
-            <div className={styles.list}>
-              <p className={styles.srOnly} aria-live="polite">
-                {stamp.components.length} components. Page {current + 1} of {pageCount}.
-              </p>
-              {pageComponents.map((c, i) => (
-                <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
-              ))}
-            </div>
-            {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
-          </>
-        )}
-
-        {/* How the score is computed: the weighted components summing to the total.
-            Length encodes each share; one accent family; the total on the right.
-            Hidden while the onchain block is expanded so the credential rows and
-            the component row both fit the fixed height (the header keeps the total
-            points either way; for a single-component SBT this bar is one segment). */}
-        {segments.length && !ocViewOpen ? (
-          <div className={styles.compute}>
-            <div className={styles.computeHead}>
-              <span className={styles.computeLabel}>How your points add up</span>
-              <span className={styles.computeTotal}>{earned} points</span>
-            </div>
-            <div
-              className={styles.computeBar}
-              role="img"
-              aria-label={`The verified components sum to ${earned} points.`}
+        {/* Score breakdown accordion (multi-component stamps only). Expanded, it
+            shows EVERY component row (Civic's Captcha / Uniqueness / Liveness all
+            reachable and readable, no clip) plus a weighted bar whose LENGTH
+            encodes each share. No "how your points add up = {total}" caption: the
+            header already states the total once, so the bar carries no number. A
+            single-component stamp has no breakdown at all (its one contribution is
+            the header total, stated once). Paginates only if a stamp ever exceeds
+            a page of components (never scrolls). */}
+        {isMulti ? (
+          <div className={styles.section}>
+            <button
+              type="button"
+              className={styles.sectionHead}
+              onClick={() => toggleSection("breakdown")}
+              aria-expanded={breakdownOpen}
             >
-              {segments.map((seg, i) => (
-                <span
-                  key={`${seg.name}-${i}`}
-                  className={styles.computeSeg}
-                  style={{ width: `${seg.pct}%`, background: seg.color }}
-                />
-              ))}
-            </div>
+              <span className={styles.sectionLabel}>Score breakdown</span>
+              <CaretDownIcon className={breakdownOpen ? styles.sectionChevOpen : styles.sectionChev} size={13} />
+            </button>
+            {breakdownOpen ? (
+              <div className={styles.sectionBody}>
+                <div className={styles.list}>
+                  <p className={styles.srOnly} aria-live="polite">
+                    {stamp.components.length} components. Page {current + 1} of {pageCount}.
+                  </p>
+                  {pageComponents.map((c, i) => (
+                    <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
+                  ))}
+                </div>
+                {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+                {segments.length ? (
+                  <div
+                    className={styles.computeBar}
+                    role="img"
+                    aria-label={`The verified components sum to ${earned} points.`}
+                  >
+                    {segments.map((seg, i) => (
+                      <span
+                        key={`${seg.name}-${i}`}
+                        className={styles.computeSeg}
+                        style={{ width: `${seg.pct}%`, background: seg.color }}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         ) : null}
 
-        {/* Onchain credential (Human ID SBT stamps only). A collapsible block so
-            the fixed drawer height is never at risk: collapsed it is one row;
-            expanded it shows a compact two-column metadata grid + a View on chain
-            link. All non-PII (see StampDetail.onchainCredential). */}
+        {/* Onchain credential accordion (Human ID SBT / attestation stamps only).
+            One coherent section: protocol + chain (with the Optimism mark), a
+            compact Issued / Expires line, the verified issuer as a named on-chain
+            identity with a view link, the credential type, revocation status, and
+            a protocol-accurate "View on chain" / "View on Sign Protocol" link. All
+            non-PII (see StampDetail.onchainCredential). */}
         {oc ? (
-          <div className={styles.oc}>
+          <div className={styles.section}>
             <button
               type="button"
-              className={styles.ocHead}
-              onClick={() => setOcOpen((v) => !v)}
-              aria-expanded={ocOpen}
+              className={styles.sectionHead}
+              onClick={() => toggleSection("onchain")}
+              aria-expanded={onchainOpen}
             >
               <span className={styles.ocHeadIcon} aria-hidden="true">
                 <LinkIcon size={13} strokeWidth={1.9} />
               </span>
-              <span className={styles.ocHeadLabel}>Onchain credential</span>
-              <CaretDownIcon className={ocOpen ? styles.ocChevOpen : styles.ocChev} size={13} />
+              <span className={styles.sectionLabel}>Onchain credential</span>
+              <CaretDownIcon className={onchainOpen ? styles.sectionChevOpen : styles.sectionChev} size={13} />
             </button>
-            {ocOpen ? (
+            {onchainOpen ? (
               <div className={styles.ocBody}>
+                {/* Protocol + chain, labeled with a logo (never the word alone). */}
+                <div className={styles.ocProtocol}>
+                  {oc.protocol === "sbt" ? (
+                    <span className={styles.ocChain} aria-hidden="true">
+                      <OptimismIcon size={14} />
+                    </span>
+                  ) : null}
+                  <span className={styles.ocProtocolText}>
+                    {oc.protocol === "sbt" ? `Onchain SBT · ${oc.chain}` : "Sign Protocol attestation"}
+                  </span>
+                </div>
+
+                {/* Issued / Expires on ONE line. For a Sign Protocol attestation
+                    (Proof of Clean Hands) the issued line is privacy-accurate:
+                    the identity is held encrypted, so there is nothing to decode. */}
+                {oc.protocol === "sign" ? (
+                  <>
+                    {oc.issued ? (
+                      <p className={styles.ocLine}>
+                        Issued {oc.issued} · identity encrypted to the Human Network
+                      </p>
+                    ) : null}
+                    {oc.expires ? <p className={styles.ocLine}>Expires {oc.expires}</p> : null}
+                  </>
+                ) : oc.issued || oc.expires ? (
+                  <p className={styles.ocLine}>
+                    {oc.issued ? `Issued ${oc.issued}` : ""}
+                    {oc.issued && oc.expires ? " · " : ""}
+                    {oc.expires ? `Expires ${oc.expires}` : ""}
+                  </p>
+                ) : null}
+
                 <dl className={styles.ocGrid}>
-                  {oc.issued ? (
-                    <div className={styles.ocItem}>
-                      <dt className={styles.ocKey}>Issued</dt>
-                      <dd className={styles.ocVal}>{oc.issued}</dd>
-                    </div>
-                  ) : null}
-                  {oc.expires ? (
-                    <div className={styles.ocItem}>
-                      <dt className={styles.ocKey}>Expires</dt>
-                      <dd className={styles.ocVal}>{oc.expires}</dd>
-                    </div>
-                  ) : null}
                   <div className={styles.ocItem}>
-                    <dt className={styles.ocKey}>Chain</dt>
-                    <dd className={styles.ocVal}>{oc.chain}</dd>
+                    <dt className={styles.ocKey}>Credential</dt>
+                    <dd className={styles.ocVal}>{oc.credential}</dd>
+                  </div>
+                  <div className={styles.ocItem}>
+                    <dt className={styles.ocKey}>Verified issuer</dt>
+                    <dd className={styles.ocVal}>
+                      {oc.issuerUrl ? (
+                        <a
+                          className={styles.ocIssuer}
+                          href={oc.issuerUrl}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                        >
+                          <span className={styles.ocVerifiedMark} aria-hidden="true">
+                            <CheckIcon size={9} strokeWidth={2.8} />
+                          </span>
+                          {oc.issuer}
+                        </a>
+                      ) : (
+                        <span className={styles.ocIssuer}>
+                          <span className={styles.ocVerifiedMark} aria-hidden="true">
+                            <CheckIcon size={9} strokeWidth={2.8} />
+                          </span>
+                          {oc.issuer}
+                        </span>
+                      )}
+                    </dd>
                   </div>
                   <div className={styles.ocItem}>
                     <dt className={styles.ocKey}>Status</dt>
@@ -563,15 +656,8 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
                       {oc.revoked ? "Revoked" : "Not revoked"}
                     </dd>
                   </div>
-                  <div className={styles.ocItem}>
-                    <dt className={styles.ocKey}>Credential</dt>
-                    <dd className={styles.ocVal}>{oc.credential}</dd>
-                  </div>
-                  <div className={styles.ocItem}>
-                    <dt className={styles.ocKey}>Issuer</dt>
-                    <dd className={styles.ocVal}>{oc.issuer}</dd>
-                  </div>
                 </dl>
+
                 {oc.explorerUrl ? (
                   <a
                     className={styles.ocView}
@@ -580,7 +666,7 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
                     rel="noreferrer noopener"
                   >
                     <LinkIcon size={13} strokeWidth={1.9} />
-                    View on chain
+                    {oc.protocol === "sign" ? "View on Sign Protocol" : "View on chain"}
                   </a>
                 ) : null}
               </div>

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -35,20 +35,6 @@ export type StampComponent = {
   expiry?: string;
   /** Optional row icon (an emoji, an <img>, or an icon node). Omit for no icon. */
   icon?: React.ReactNode;
-  /**
-   * TODO(sbt-metadata): the in-progress research pass is sourcing the real SBT
-   * fields for each component (issued date, on-chain SBT id, chain). They render
-   * as a quiet sub-line under the component name when present; until the data
-   * lands this stays undefined so nothing shows. Drop the values in here.
-   */
-  sbt?: {
-    /** Human date the credential was issued, e.g. "Issued Apr 12". */
-    issued?: string;
-    /** Short SBT token id, e.g. "#4821". */
-    sbtId?: string;
-    /** Chain the SBT lives on, e.g. "Optimism". */
-    chain?: string;
-  };
 };
 
 /**
@@ -61,6 +47,48 @@ export type StampDetail = Stamp & {
   components: StampComponent[];
   /* `description` is inherited from Stamp (surfaced as the grid tooltip and the
      drawer's own description line). */
+  /**
+   * Onchain credential metadata, for the Human ID SBT stamps ONLY (Government ID,
+   * Biometrics, Phone, Proof of Clean Hands). Everything here is non-PII.
+   *
+   * Data model: these come from the Human ID SDK getters. The SBT reads
+   * (getKycSBTByAddress / getPhoneSBTByAddress / getBiometricsSBTByAddress)
+   * return { expiry, publicValues: [expiry, recipient, actionId, nullifier,
+   * issuer], revoked }; Proof of Clean Hands returns a Sign Protocol attestation
+   * ({ attestTimestamp, validUntil, revoked, attestationId }). The embed already
+   * fetches these in useHumanIDVerification and discards them, so this block is
+   * purely presentational: seed it via props, render, done.
+   *
+   * DELIBERATELY NOT SURFACED: name, DOB, document number, nationality, phone
+   * number, biometric data, the ABI `data` blob, and crucially the
+   * nullifier / indexingValue (a stable per-user correlation handle). Leaving the
+   * nullifier out is the privacy point, not an oversight. There is no ERC-721
+   * tokenId and no mint transaction in the SBT read path, so no "SBT #1234" id is
+   * shown; only Proof of Clean Hands has an attestation id / tx for its link.
+   *
+   * Named `onchainCredential` (not `onchain`) because `Stamp.onchain` already
+   * carries the minted / mintable / none state string.
+   */
+  onchainCredential?: {
+    /** Issue date, e.g. "Apr 12, 2026". Omit when unknown (never invented). */
+    issued?: string;
+    /** Expiry date, e.g. "Oct 17, 2026". Mirrors the header clock's validity. */
+    expires?: string;
+    /** Chain the credential lives on, e.g. "Optimism". */
+    chain: string;
+    /** Revocation flag from the SBT / attestation; false renders "Not revoked". */
+    revoked: boolean;
+    /** Credential type, e.g. "Government ID". */
+    credential: string;
+    /** Issuing authority, e.g. "Human ID". */
+    issuer: string;
+    /**
+     * Explorer link: the HubV3 contract
+     * (0x2AA822e264F8cc31A2b9C22f39e5551241e94DfB) on Optimism for the SBTs, or
+     * the attestation for Proof of Clean Hands. Omit to drop the affordance.
+     */
+    explorerUrl?: string;
+  };
 };
 
 /** The bottom-pinned action the drawer resolves to. One primary action. */
@@ -106,6 +134,13 @@ export type StampDetailDrawerProps = {
 
   /** Override the on-chain status pill's glass tooltip copy. */
   statusTooltip?: React.ReactNode;
+  /**
+   * Render the "Onchain credential" block expanded on first paint (Human ID SBT
+   * stamps only, and only when `stamp.onchainCredential` is supplied). Defaults
+   * to collapsed so the fixed drawer height is never at risk; open it to show the
+   * metadata rows.
+   */
+  defaultOnchainOpen?: boolean;
 };
 
 const ONCHAIN_PILL: Record<StampOnchain, string> = {
@@ -145,16 +180,11 @@ const paginate = <T,>(items: T[], per: number): T[][] => {
 /**
  * One sub-credential row: [meaningful icon, if any] + name + verified / expiry
  * state + points chip. No filler icon: when a component has no real icon the row
- * simply leads with the name (the old placeholder star was meaningless). An
- * optional SBT metadata sub-line (issued / id / chain) shows when present.
+ * simply leads with the name (the old placeholder star was meaningless).
  */
 const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) => {
-  const { name, points, verified, expiry, icon, sbt } = component;
+  const { name, points, verified, expiry, icon } = component;
   const state = verified ? (expiry ? expiry : "Verified") : "Not verified yet";
-  // SBT slot: joined into one quiet line, only for the parts that are present.
-  const sbtLine = sbt
-    ? [sbt.issued, sbt.sbtId, sbt.chain].filter(Boolean).join("  ·  ")
-    : "";
   return (
     <div className={styles.row} data-verified={verified ? "true" : "false"}>
       {icon ? (
@@ -174,7 +204,6 @@ const ComponentRow: React.FC<{ component: StampComponent }> = ({ component }) =>
           ) : null}
           {state}
         </span>
-        {sbtLine ? <span className={styles.rowSbt}>{sbtLine}</span> : null}
       </span>
       <span className={styles.rowPoints}>+{points}</span>
     </div>
@@ -250,10 +279,25 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
   verifiedLabel,
   renewLabel,
   statusTooltip,
+  defaultOnchainOpen = false,
 }) => {
   const rootRef = useRef<HTMLDivElement>(null);
   const accent = useAccentRgb(rootRef);
   const [page, setPage] = useState(0);
+
+  // Onchain credential block: collapsed by default so the fixed drawer height is
+  // never at risk. Reset when the stamp changes.
+  const oc = stamp.onchainCredential;
+  const [ocOpen, setOcOpen] = useState(defaultOnchainOpen);
+  useEffect(() => {
+    setOcOpen(defaultOnchainOpen);
+  }, [stamp.id, defaultOnchainOpen]);
+  // When the onchain block is open it takes over the drawer's flexible middle:
+  // the component list, its pager, and the one-segment compute bar step aside so
+  // the full credential rows fit the fixed height with no truncation or scroll.
+  // Human ID SBT stamps carry a single component that just restates the header,
+  // so nothing meaningful is hidden. Everything returns when the block collapses.
+  const ocViewOpen = Boolean(oc && ocOpen);
 
   // Description: clamped to two lines by default, with an inline "more" toggle so
   // the full text is always reachable (no dead-end truncation). "more" only shows
@@ -414,7 +458,7 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
           </div>
         </header>
 
-        {stamp.description ? (
+        {stamp.description && !ocViewOpen ? (
           <div className={styles.descWrap}>
             <p ref={descRef} className={`${styles.desc} ${descOpen ? styles.descOpen : ""}`}>
               {stamp.description}
@@ -432,21 +476,29 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
           </div>
         ) : null}
 
-        {/* Sub-credential rows, paginated (never scrolled). */}
-        <div className={styles.list}>
-          <p className={styles.srOnly} aria-live="polite">
-            {stamp.components.length} components. Page {current + 1} of {pageCount}.
-          </p>
-          {pageComponents.map((c, i) => (
-            <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
-          ))}
-        </div>
-
-        {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+        {/* Sub-credential rows, paginated (never scrolled). While the onchain block
+            is open this whole region (and the description + compute bar) steps
+            aside for a focused credential view, so nothing is clipped or scrolls. */}
+        {ocViewOpen ? null : (
+          <>
+            <div className={styles.list}>
+              <p className={styles.srOnly} aria-live="polite">
+                {stamp.components.length} components. Page {current + 1} of {pageCount}.
+              </p>
+              {pageComponents.map((c, i) => (
+                <ComponentRow key={`${c.name}-${current}-${i}`} component={c} />
+              ))}
+            </div>
+            {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+          </>
+        )}
 
         {/* How the score is computed: the weighted components summing to the total.
-            Length encodes each share; one accent family; the total on the right. */}
-        {segments.length ? (
+            Length encodes each share; one accent family; the total on the right.
+            Hidden while the onchain block is expanded so the credential rows and
+            the component row both fit the fixed height (the header keeps the total
+            points either way; for a single-component SBT this bar is one segment). */}
+        {segments.length && !ocViewOpen ? (
           <div className={styles.compute}>
             <div className={styles.computeHead}>
               <span className={styles.computeLabel}>How your points add up</span>
@@ -465,6 +517,74 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
                 />
               ))}
             </div>
+          </div>
+        ) : null}
+
+        {/* Onchain credential (Human ID SBT stamps only). A collapsible block so
+            the fixed drawer height is never at risk: collapsed it is one row;
+            expanded it shows a compact two-column metadata grid + a View on chain
+            link. All non-PII (see StampDetail.onchainCredential). */}
+        {oc ? (
+          <div className={styles.oc}>
+            <button
+              type="button"
+              className={styles.ocHead}
+              onClick={() => setOcOpen((v) => !v)}
+              aria-expanded={ocOpen}
+            >
+              <span className={styles.ocHeadIcon} aria-hidden="true">
+                <LinkIcon size={13} strokeWidth={1.9} />
+              </span>
+              <span className={styles.ocHeadLabel}>Onchain credential</span>
+              <CaretDownIcon className={ocOpen ? styles.ocChevOpen : styles.ocChev} size={13} />
+            </button>
+            {ocOpen ? (
+              <div className={styles.ocBody}>
+                <dl className={styles.ocGrid}>
+                  {oc.issued ? (
+                    <div className={styles.ocItem}>
+                      <dt className={styles.ocKey}>Issued</dt>
+                      <dd className={styles.ocVal}>{oc.issued}</dd>
+                    </div>
+                  ) : null}
+                  {oc.expires ? (
+                    <div className={styles.ocItem}>
+                      <dt className={styles.ocKey}>Expires</dt>
+                      <dd className={styles.ocVal}>{oc.expires}</dd>
+                    </div>
+                  ) : null}
+                  <div className={styles.ocItem}>
+                    <dt className={styles.ocKey}>Chain</dt>
+                    <dd className={styles.ocVal}>{oc.chain}</dd>
+                  </div>
+                  <div className={styles.ocItem}>
+                    <dt className={styles.ocKey}>Status</dt>
+                    <dd className={styles.ocVal} data-revoked={oc.revoked ? "true" : "false"}>
+                      {oc.revoked ? "Revoked" : "Not revoked"}
+                    </dd>
+                  </div>
+                  <div className={styles.ocItem}>
+                    <dt className={styles.ocKey}>Credential</dt>
+                    <dd className={styles.ocVal}>{oc.credential}</dd>
+                  </div>
+                  <div className={styles.ocItem}>
+                    <dt className={styles.ocKey}>Issuer</dt>
+                    <dd className={styles.ocVal}>{oc.issuer}</dd>
+                  </div>
+                </dl>
+                {oc.explorerUrl ? (
+                  <a
+                    className={styles.ocView}
+                    href={oc.explorerUrl}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <LinkIcon size={13} strokeWidth={1.9} />
+                    View on chain
+                  </a>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/src/redesign/StampDetailDrawer.tsx
+++ b/src/redesign/StampDetailDrawer.tsx
@@ -14,6 +14,7 @@ import {
   StarIcon,
 } from "./icons";
 import { deriveTints } from "./deriveTints";
+import { formatExpiry } from "./expiry";
 import { useAccentRgb, useReducedMotion } from "./hooks";
 import type { ShellSize } from "./PassportShell";
 
@@ -271,6 +272,10 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
   const action = deriveAction(stamp, actionState);
   const showRenew = Boolean(onRenew) && stamp.verified && action !== "claim";
 
+  // Every stamp expires as a whole. The header states it in full ("Valid for N
+  // days" / "Expires {date}" / "Expired"); Human ID SBTs add the auto-renew note.
+  const expiry = formatExpiry(stamp.expirationDate);
+
   const compact = size !== "full";
   const medallionPx = compact ? 40 : 46;
 
@@ -349,6 +354,25 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
 
         {stamp.description ? <p className={styles.desc}>{stamp.description}</p> : null}
 
+        {/* Expiry: a stamp expires as a whole. Amber when expiring soon, warn when
+            expired. Human ID SBTs carry the auto-renew note beside it. */}
+        {expiry ? (
+          <div className={styles.expiry} data-state={expiry.state}>
+            <span className={styles.expiryIcon} aria-hidden="true">
+              <ClockIcon size={13} strokeWidth={1.9} />
+            </span>
+            <span className={styles.expiryText}>
+              {expiry.long}
+              {stamp.isHumanId ? (
+                <span className={styles.expiryNote}>
+                  {" "}
+                  Auto renews after 90 days, full reverification after a year.
+                </span>
+              ) : null}
+            </span>
+          </div>
+        ) : null}
+
         {/* Sub-credential rows, paginated (never scrolled). */}
         <div className={styles.list}>
           <p className={styles.srOnly} aria-live="polite">
@@ -394,7 +418,7 @@ export const StampDetailDrawer: React.FC<StampDetailDrawerProps> = ({
               <span className={styles.ctaIcon}>
                 <StarIcon size={15} strokeWidth={1.9} />
               </span>
-              <span className={styles.ctaLabel}>{mintLabel ?? "Mint reward"}</span>
+              <span className={styles.ctaLabel}>{mintLabel ?? "Notarize stamp"}</span>
             </button>
           ) : action === "claim" ? (
             <button type="button" className={styles.cta} onClick={onClaim}>

--- a/src/redesign/StampsWindow.module.css
+++ b/src/redesign/StampsWindow.module.css
@@ -169,6 +169,10 @@
   border: 0;
   background: transparent;
   cursor: pointer;
+  /* Fill the grid cell whether the direct parent is the cell or the Tooltip
+   * trigger wrapper (added when a stamp has a description), so the medallion
+   * stays centered under both. */
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -225,6 +229,39 @@
   );
 }
 
+/* Mintable (verified, not notarized yet): an emerald outline invite. Emerald,
+ * never gold. A soft ring lifts it above the calm off-chain medallion. */
+.medallion[data-verified="true"][data-onchain="mintable"] {
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 0 0 1.5px rgba(var(--accent), 0.45);
+}
+
+/* Minted (notarized on-chain): the "special" state. A stronger emerald ring plus
+ * an outer glow, and a subtle settle-in on mount (below). */
+.medallion[data-verified="true"][data-onchain="minted"] {
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 0 0 1.5px rgba(var(--accent), 0.6),
+    0 0 16px rgba(var(--accent), 0.4);
+}
+.medallionMinted {
+  animation: rdMintSettle var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459) both;
+}
+@keyframes rdMintSettle {
+  0% {
+    transform: scale(0.92);
+  }
+  55% {
+    transform: scale(1.04);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 .face {
   width: 100%;
   height: 100%;
@@ -269,12 +306,16 @@
   height: 17px;
 }
 
-/* Expired stamp: reads as lapsed at a glance, on the grid AND in the drawer header.
- * The emerald rim drops to a neutral ring and the face desaturates, so the earned
- * emphasis drains away. Grayscale stays on the FACE (not the whole medallion) so
- * the amber "Expired" chip keeps its warn color instead of graying out with it. */
+/* Expired stamp: reads as lapsed at a glance, on the grid AND in the drawer
+ * header. The emerald rim drops to a neutral ring, the face desaturates, and a
+ * muted outline replaces any earned glow, so the emphasis drains away and it
+ * reads inactive. Declared AFTER the minted / mintable rules so it always wins. */
 .medallion[data-expired="true"] {
   background: rgba(var(--on-surface), 0.16);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 0 0 1px rgba(var(--on-surface), 0.2);
+  animation: none;
 }
 .medallion[data-expired="true"] .face {
   filter: grayscale(1);
@@ -283,8 +324,8 @@
   opacity: 0.55;
 }
 
-/* Corner on-chain pip: the ONE carrier of on-chain state. A surface-colored ring
- * punches it off the medallion (a notch, not a divider). */
+/* Minted chain-link pip: the single "notarized on chain" mark, emerald. A
+ * surface-colored ring punches it off the medallion (a notch, not a divider). */
 .pip {
   position: absolute;
   top: -2px;
@@ -294,19 +335,30 @@
   border-radius: var(--radius-pill-c6dbf459);
   display: grid;
   place-items: center;
-  box-shadow: 0 0 0 2px rgb(var(--surface));
-}
-.medallion[data-onchain="minted"] .pip {
   color: rgb(var(--on-accent));
   background: rgb(var(--accent));
+  box-shadow: 0 0 0 2px rgb(var(--surface));
 }
-.medallion[data-onchain="mintable"] .pip {
-  color: rgb(var(--on-accent));
-  /* gold: reuse the amber "attention / available" semantic token. */
+.medallionSm .pip {
+  width: 15px;
+  height: 15px;
+}
+
+/* Expiring-soon dot: the ONLY amber on the medallion, a small corner indicator
+ * (mirrors the pip corner). No text; the drawer's timer tooltip states the days. */
+.expiringDot {
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-pill-c6dbf459);
   background: rgb(var(--warn));
+  box-shadow: 0 0 0 2px rgb(var(--surface));
 }
-.medallion[data-onchain="none"] .pip {
-  background: rgba(var(--on-surface), 0.16);
+.medallionSm .expiringDot {
+  width: 9px;
+  height: 9px;
 }
 
 /* Points chip: overlaps the medallion foot like a badge ribbon. Emerald when
@@ -329,42 +381,6 @@
   background: rgb(var(--accent));
   color: rgb(var(--on-accent));
   box-shadow: var(--shadow-sm-c6dbf459);
-}
-
-/* Compact expiry chip: top-left corner of the medallion (mirrors the on-chain
- * pip top-right), so expiry reads without adding a caption line that would grow
- * the badge and risk overflow. Muted when healthy, amber when soon, warn when
- * expired. Adds no layout height (absolutely positioned). */
-.expiryChip {
-  position: absolute;
-  top: -6px;
-  left: -4px;
-  padding: 0 5px;
-  border-radius: var(--radius-pill-c6dbf459);
-  font-size: 9px;
-  line-height: 15px;
-  height: 15px;
-  font-weight: var(--weight-bold-c6dbf459);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-  box-shadow: 0 0 0 2px rgb(var(--surface));
-  background: rgba(var(--on-surface), 0.14);
-  color: rgba(var(--on-surface), 0.72);
-}
-.expiryChip[data-state="soon"] {
-  background: rgb(var(--warn));
-  color: rgb(var(--on-accent));
-}
-.expiryChip[data-state="expired"] {
-  background: rgb(var(--warn));
-  color: rgb(var(--on-accent));
-}
-.medallionSm .expiryChip {
-  top: -5px;
-  font-size: 8px;
-  line-height: 13px;
-  height: 13px;
 }
 
 .name {
@@ -561,10 +577,6 @@
   bottom: -5px;
   padding: 0 6px;
 }
-.medallionSm .pip {
-  width: 15px;
-  height: 15px;
-}
 .miniWin .name {
   -webkit-line-clamp: 1;
   min-height: calc(var(--font-size-xs-c6dbf459) * var(--line-tight-c6dbf459));
@@ -616,7 +628,8 @@
   .pagerDot {
     transition: none;
   }
-  .spin {
+  .spin,
+  .medallionMinted {
     animation: none;
   }
 }

--- a/src/redesign/StampsWindow.module.css
+++ b/src/redesign/StampsWindow.module.css
@@ -74,6 +74,88 @@
   color: rgba(var(--on-surface), 0.55);
 }
 
+/* ---- category selector: the primary nav. One segment per real category. ---- */
+.tabs {
+  display: flex;
+  gap: var(--space-1-c6dbf459);
+  width: 100%;
+  padding: 3px;
+  border-radius: var(--radius-lg-c6dbf459);
+  /* A soft tonal trough holds the segments; the active one lifts out of it. No
+   * hard divider lines between segments (§ no-hard-lines). */
+  background: rgba(var(--on-surface), 0.06);
+}
+.tab {
+  appearance: none;
+  border: 0;
+  flex: 1 1 0;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 34px;
+  padding: 0 var(--space-2-c6dbf459);
+  border-radius: var(--radius-md-c6dbf459);
+  background: transparent;
+  color: rgba(var(--on-surface), 0.62);
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.tab:hover {
+  color: rgb(var(--on-surface));
+}
+.tabOn {
+  background: rgb(var(--surface));
+  color: rgb(var(--on-surface));
+  box-shadow: var(--shadow-sm-c6dbf459);
+}
+.tabOn .tabCount {
+  color: rgb(var(--accent));
+}
+.tab:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.tabIcon {
+  display: inline-flex;
+  flex: none;
+}
+.tabIcon svg {
+  width: 18px;
+  height: 18px;
+}
+.tabCount {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Active-category heading: the verbatim name (single line, ellipsized on the one
+ * very long name) + its verified count. Tonal, no rule. */
+.catBar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+  margin-top: var(--space-2-c6dbf459);
+}
+.catName {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--font-size-md-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -176,6 +258,30 @@
   font-size: 22px;
   line-height: 1;
 }
+/* Real stamp icons are inline SVGs (currentColor). Size them to the medallion so
+ * they read the same whether the source viewBox is 24, 40, or 48. */
+.glyph svg {
+  width: 22px;
+  height: 22px;
+}
+.medallionSm .glyph svg {
+  width: 17px;
+  height: 17px;
+}
+
+/* Expired stamp: reads as lapsed at a glance, on the grid AND in the drawer header.
+ * The emerald rim drops to a neutral ring and the face desaturates, so the earned
+ * emphasis drains away. Grayscale stays on the FACE (not the whole medallion) so
+ * the amber "Expired" chip keeps its warn color instead of graying out with it. */
+.medallion[data-expired="true"] {
+  background: rgba(var(--on-surface), 0.16);
+}
+.medallion[data-expired="true"] .face {
+  filter: grayscale(1);
+}
+.medallion[data-expired="true"] .glyph {
+  opacity: 0.55;
+}
 
 /* Corner on-chain pip: the ONE carrier of on-chain state. A surface-colored ring
  * punches it off the medallion (a notch, not a divider). */
@@ -223,6 +329,42 @@
   background: rgb(var(--accent));
   color: rgb(var(--on-accent));
   box-shadow: var(--shadow-sm-c6dbf459);
+}
+
+/* Compact expiry chip: top-left corner of the medallion (mirrors the on-chain
+ * pip top-right), so expiry reads without adding a caption line that would grow
+ * the badge and risk overflow. Muted when healthy, amber when soon, warn when
+ * expired. Adds no layout height (absolutely positioned). */
+.expiryChip {
+  position: absolute;
+  top: -6px;
+  left: -4px;
+  padding: 0 5px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: 9px;
+  line-height: 15px;
+  height: 15px;
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  box-shadow: 0 0 0 2px rgb(var(--surface));
+  background: rgba(var(--on-surface), 0.14);
+  color: rgba(var(--on-surface), 0.72);
+}
+.expiryChip[data-state="soon"] {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-accent));
+}
+.expiryChip[data-state="expired"] {
+  background: rgb(var(--warn));
+  color: rgb(var(--on-accent));
+}
+.medallionSm .expiryChip {
+  top: -5px;
+  font-size: 8px;
+  line-height: 13px;
+  height: 13px;
 }
 
 .name {

--- a/src/redesign/StampsWindow.module.css
+++ b/src/redesign/StampsWindow.module.css
@@ -91,11 +91,12 @@
   flex: 1 1 0;
   min-width: 0;
   display: inline-flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 5px;
+  gap: 1px;
   height: 34px;
-  padding: 0 var(--space-2-c6dbf459);
+  padding: 0 var(--space-1-c6dbf459);
   border-radius: var(--radius-md-c6dbf459);
   background: transparent;
   color: rgba(var(--on-surface), 0.62);
@@ -120,19 +121,27 @@
   outline: 2px solid rgb(var(--accent));
   outline-offset: 2px;
 }
-.tabIcon {
-  display: inline-flex;
-  flex: none;
-}
-.tabIcon svg {
-  width: 18px;
-  height: 18px;
-}
-.tabCount {
+/* Named tab: short category name on top, its verified/total count beneath, so
+ * the segment reads as a labeled category, never a bare glyph or star + number. */
+.tabName {
+  max-width: 100%;
   font-size: var(--font-size-xs-c6dbf459);
   font-weight: var(--weight-semibold-c6dbf459);
-  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tabCount {
+  font-size: 11px;
+  font-weight: var(--weight-medium-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  white-space: nowrap;
+  color: rgba(var(--on-surface), 0.55);
+}
+.tabOn .tabName {
+  color: rgb(var(--on-surface));
 }
 
 /* Active-category heading: the verbatim name (single line, ellipsized on the one
@@ -148,12 +157,39 @@
 .catName {
   flex: 1 1 auto;
   min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: var(--font-size-md-c6dbf459);
   font-weight: var(--weight-semibold-c6dbf459);
   color: rgb(var(--on-surface));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.catGlyph {
+  flex: none;
+  display: inline-flex;
+  color: rgb(var(--accent));
+}
+.catGlyph svg {
+  width: 16px;
+  height: 16px;
+}
+.catNameText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Overall passport progress, plainly labeled (never a bare star + number). */
+.catSummary {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .grid {
@@ -239,27 +275,14 @@
 }
 
 /* Minted (notarized on-chain): the "special" state. A stronger emerald ring plus
- * an outer glow, and a subtle settle-in on mount (below). */
+ * an outer glow, read together with the static chain-link badge top-right. No
+ * settle animation: the minted mark is self-evident and legible at a glance. */
 .medallion[data-verified="true"][data-onchain="minted"] {
   box-shadow:
     var(--shadow-sm-c6dbf459),
     inset 0 1px 0 rgba(255, 255, 255, 0.3),
     0 0 0 1.5px rgba(var(--accent), 0.6),
     0 0 16px rgba(var(--accent), 0.4);
-}
-.medallionMinted {
-  animation: rdMintSettle var(--motion-slow-c6dbf459) var(--ease-standard-c6dbf459) both;
-}
-@keyframes rdMintSettle {
-  0% {
-    transform: scale(0.92);
-  }
-  55% {
-    transform: scale(1.04);
-  }
-  100% {
-    transform: scale(1);
-  }
 }
 
 .face {
@@ -344,12 +367,14 @@
   height: 15px;
 }
 
-/* Expiring-soon dot: the ONLY amber on the medallion, a small corner indicator
- * (mirrors the pip corner). No text; the drawer's timer tooltip states the days. */
+/* Expiring-soon dot: the ONLY amber on the medallion, a small indicator in the
+ * SAME top-right corner as the minted badge (they never render together, so the
+ * corner holds exactly one indicator and there is no top-left mark). No text; the
+ * medallion tooltip and the drawer timer name the days. */
 .expiringDot {
   position: absolute;
   top: -3px;
-  left: -3px;
+  right: -3px;
   width: 10px;
   height: 10px;
   border-radius: var(--radius-pill-c6dbf459);
@@ -628,8 +653,7 @@
   .pagerDot {
     transition: none;
   }
-  .spin,
-  .medallionMinted {
+  .spin {
     animation: none;
   }
 }

--- a/src/redesign/StampsWindow.module.css
+++ b/src/redesign/StampsWindow.module.css
@@ -1,0 +1,480 @@
+/*
+ * StampsWindow - stamps as glass medallion plaques (SOP §4). Each stamp is a real
+ * badge (conic rim + embossed face + depth + a corner pip), grouped by category
+ * (tonal header, no hard line), paginated and NEVER scrolled. Tokens only (§1),
+ * legible in both themes (§2/§8), motion degrades under reduced-motion (§4).
+ */
+
+.window {
+  display: flex;
+  flex-direction: column;
+  /* Fill the shell's fixed content height so switching tabs never jumps and the
+   * verify CTA bottom-pins at the same y as the other windows' primary CTA. */
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ---- header: title + a quiet verified count. Tonal, no hard line. ---- */
+.head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+}
+.title {
+  font-size: var(--font-size-lg-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  color: rgb(var(--on-surface));
+}
+.count {
+  flex: none;
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  color: rgba(var(--on-surface), 0.62);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- paged region: grows to fill, pushing the pager + CTA to the bottom. ---- */
+.pages {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3-c6dbf459);
+  margin-top: var(--space-3-c6dbf459);
+  align-content: flex-start;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2-c6dbf459);
+}
+
+/* Category header: tone + space, never a rule (§ no-hard-lines). */
+.catHead {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--on-surface), 0.55);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  column-gap: var(--space-2-c6dbf459);
+  row-gap: var(--space-3-c6dbf459);
+}
+
+/* ---- one badge: medallion + name, the whole thing is the tap target ---- */
+.badge {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-1-c6dbf459) 2px var(--space-1-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  color: inherit;
+  font-family: inherit;
+  transition: transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.badge:hover {
+  transform: translateY(-1px);
+}
+.badge:hover .medallion {
+  filter: brightness(1.05);
+}
+.badge:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- the medallion: rim (conic) + embossed face + depth ---- */
+.medallion {
+  --rd-med: 50px;
+  position: relative;
+  width: var(--rd-med);
+  height: var(--rd-med);
+  flex: none;
+  border-radius: var(--radius-pill-c6dbf459);
+  /* rim: a soft metallic ring drawn as a conic gradient behind the face. Neutral
+   * (unearned) by default; emerald when verified. Padding reveals it as the rim. */
+  padding: 2px;
+  background: conic-gradient(
+    from 210deg,
+    rgba(var(--on-surface), 0.05),
+    rgba(var(--on-surface), 0.2),
+    rgba(var(--on-surface), 0.05),
+    rgba(var(--on-surface), 0.16),
+    rgba(var(--on-surface), 0.05)
+  );
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  transition: filter var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.medallion[data-verified="true"] {
+  background: conic-gradient(
+    from 210deg,
+    rgba(var(--accent), 0.35),
+    rgba(var(--accent), 0.9),
+    rgba(var(--accent), 0.4),
+    rgba(var(--accent), 0.85),
+    rgba(var(--accent), 0.35)
+  );
+}
+
+.face {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.85);
+  /* embossed plate: a top-left highlight + inset depth so it reads as struck
+   * metal, not a flat disc. */
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.35), transparent 55%),
+    rgb(var(--surface));
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.22),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.12);
+}
+.medallion[data-verified="true"] .face {
+  color: rgb(var(--on-surface));
+  background:
+    radial-gradient(circle at 34% 26%, rgba(255, 255, 255, 0.42), transparent 55%),
+    linear-gradient(160deg, rgba(var(--accent), 0.24), rgba(var(--accent), 0.1));
+}
+/* Unverified reads quieter: the face art recedes so earned badges stand out. */
+.medallion[data-verified="false"] .glyph {
+  opacity: 0.6;
+}
+
+.glyph {
+  display: grid;
+  place-items: center;
+  font-size: 22px;
+  line-height: 1;
+}
+
+/* Corner on-chain pip: the ONE carrier of on-chain state. A surface-colored ring
+ * punches it off the medallion (a notch, not a divider). */
+.pip {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 0 2px rgb(var(--surface));
+}
+.medallion[data-onchain="minted"] .pip {
+  color: rgb(var(--on-accent));
+  background: rgb(var(--accent));
+}
+.medallion[data-onchain="mintable"] .pip {
+  color: rgb(var(--on-accent));
+  /* gold: reuse the amber "attention / available" semantic token. */
+  background: rgb(var(--warn));
+}
+.medallion[data-onchain="none"] .pip {
+  background: rgba(var(--on-surface), 0.16);
+}
+
+/* Points chip: overlaps the medallion foot like a badge ribbon. Emerald when
+ * earned (verified), muted when the points are still only available. */
+.points {
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill-c6dbf459);
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-bold-c6dbf459);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  background: rgba(var(--on-surface), 0.14);
+  color: rgba(var(--on-surface), 0.72);
+}
+.medallion[data-verified="true"] .points {
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  box-shadow: var(--shadow-sm-c6dbf459);
+}
+
+.name {
+  font-size: var(--font-size-xs-c6dbf459);
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-tight-c6dbf459);
+  color: rgb(var(--on-surface));
+  text-align: center;
+  max-width: 100%;
+  /* Reserve two lines so every badge row is the SAME height whether a name wraps
+   * or not. This keeps the paged region's height deterministic, so nothing spills
+   * the fixed shell height (§ nothing outside the shell / never scroll). */
+  min-height: calc(2 * var(--font-size-xs-c6dbf459) * var(--line-tight-c6dbf459));
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ---- empty / loading center ---- */
+.center {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3-c6dbf459);
+  text-align: center;
+}
+.emptyMark {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-pill-c6dbf459);
+  display: grid;
+  place-items: center;
+  color: rgba(var(--on-surface), 0.6);
+  background: rgba(var(--on-surface), 0.06);
+}
+.emptyText {
+  margin: 0;
+  max-width: 220px;
+  font-size: var(--font-size-sm-c6dbf459);
+  line-height: var(--line-normal-c6dbf459);
+  color: rgba(var(--on-surface), 0.72);
+  text-wrap: balance;
+}
+
+.loaderWrap {
+  display: grid;
+  place-items: center;
+}
+.spin {
+  animation: rdSpin 1s linear infinite;
+  transform-origin: center;
+}
+@keyframes rdSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ---- pager: dots + arrows, never a scrollbar (matches the shell pager) ---- */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2-c6dbf459);
+  padding: var(--space-2-c6dbf459) 0 0;
+}
+.pagerArrow {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm-c6dbf459);
+  color: rgba(var(--on-surface), 0.6);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459),
+    color var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerArrow:hover:not(:disabled) {
+  background: rgba(var(--on-surface), 0.08);
+  color: rgb(var(--on-surface));
+}
+.pagerArrow:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.pagerArrow:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: -2px;
+}
+.pagerPrev {
+  transform: rotate(90deg);
+}
+.pagerNext {
+  transform: rotate(-90deg);
+}
+.pagerDots {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pagerDot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  flex: none;
+  border: 0;
+  border-radius: var(--radius-pill-c6dbf459);
+  background: rgba(var(--on-surface), 0.25);
+  cursor: pointer;
+  transition: background var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.pagerDot:hover {
+  background: rgba(var(--on-surface), 0.4);
+}
+.pagerDotOn {
+  background: rgb(var(--accent));
+}
+.pagerDot:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+
+/* ---- verify CTA: same box metric + emerald primary as the Score window ---- */
+.cta {
+  appearance: none;
+  border: 0;
+  width: 100%;
+  height: 46px;
+  margin-top: var(--space-3-c6dbf459);
+  padding: 0 var(--space-4-c6dbf459);
+  border-radius: var(--radius-lg-c6dbf459);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgb(var(--accent));
+  color: rgb(var(--on-accent));
+  font-family: var(--font-family-body-c6dbf459);
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-md-c6dbf459);
+  box-shadow: var(--shadow-sm-c6dbf459);
+  transition:
+    filter var(--motion-base-c6dbf459) var(--ease-standard-c6dbf459),
+    transform var(--motion-fast-c6dbf459) var(--ease-standard-c6dbf459);
+}
+.cta:hover {
+  filter: brightness(1.08);
+}
+.cta:active {
+  transform: translateY(1px);
+}
+.cta:focus-visible {
+  outline: 2px solid rgb(var(--accent));
+  outline-offset: 2px;
+}
+.ctaIcon {
+  display: inline-flex;
+}
+.ctaLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* Inline (auto-width) CTA used by the pill row. */
+.ctaInline {
+  width: auto;
+  flex: none;
+  height: 34px;
+  margin-top: 0;
+  padding: 0 var(--space-3-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+}
+
+/* ---- mini: condensed half card. Smaller medallions, one header, no CTA. ---- */
+.miniWin .grid {
+  row-gap: var(--space-3-c6dbf459);
+}
+.medallionSm {
+  --rd-med: 42px;
+}
+.medallionSm .glyph {
+  font-size: 16px;
+}
+.medallionSm .points {
+  bottom: -5px;
+  padding: 0 6px;
+}
+.medallionSm .pip {
+  width: 15px;
+  height: 15px;
+}
+.miniWin .name {
+  -webkit-line-clamp: 1;
+  min-height: calc(var(--font-size-xs-c6dbf459) * var(--line-tight-c6dbf459));
+}
+
+/* ---- pill: one short status row: mini stack + count + one action. ---- */
+.pillWin {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2-c6dbf459);
+  width: 100%;
+}
+.pillStack {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+}
+/* Overlap the mini medallions into a compact cluster. */
+.pillStack .medallion {
+  margin-right: -12px;
+  box-shadow:
+    var(--shadow-sm-c6dbf459),
+    0 0 0 2px rgb(var(--surface));
+}
+.pillStack .medallion:last-child {
+  margin-right: 0;
+}
+/* The pill has no room for the points ribbon; keep the stack to face + pip. */
+.pillStack .points {
+  display: none;
+}
+.pillText {
+  flex: 1;
+  min-width: 0;
+  font-weight: var(--weight-semibold-c6dbf459);
+  font-size: var(--font-size-sm-c6dbf459);
+  color: rgb(var(--on-surface));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .badge,
+  .medallion,
+  .cta,
+  .pagerArrow,
+  .pagerDot {
+    transition: none;
+  }
+  .spin {
+    animation: none;
+  }
+}

--- a/src/redesign/StampsWindow.stories.tsx
+++ b/src/redesign/StampsWindow.stories.tsx
@@ -6,7 +6,8 @@ import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS } from "./storyFrame
 
 // One stamp of each state, all in a single category so they land on one page: a
 // side-by-side read of minted / mintable / unminted / expiring / expired /
-// unverified. Everything is emerald except the small amber "expiring" dot.
+// unverified. Everything is emerald except the small amber "expiring" dot, and
+// every status indicator sits in the one top-right corner.
 const pick = (id: string): Stamp => ({
   ...SAMPLE_MEDALLION_STAMPS.find((s) => s.id === id)!,
   category: "Stamp states",
@@ -54,7 +55,7 @@ export const FullGrid: Story = {
     docs: {
       description: {
         story:
-          "The real catalog, navigated by category. The segmented control at the top carries the three real Passport categories (Physical Verification, Blockchain Networks and Activities, Web2 Platforms & Services), each with a verified/total count; the active category name shows below it. Each medallion is now pared to icon + name + points, and its state is carried by the medallion itself: a calm emerald glass when verified off-chain, an emerald outline when mintable, and an emerald glow + chain-link pip + a subtle settle when minted on chain. Hover or focus any medallion to see a tooltip describing what the stamp does. The persistent compact score sits in the shell chrome, top-left.",
+          "The real catalog, navigated by category. The segmented control at the top carries the three real Passport categories as NAMED tabs (Physical, Blockchain, Web2), each with its own verified/total count; the active category's verbatim name shows below it, beside a plainly labeled overall summary ('N of M verified'). There is no ambiguous star + number pill. Each medallion is pared to icon + name + points, and its state is carried by the medallion itself: a calm emerald glass when verified off-chain, an emerald outline when mintable, and a static emerald glow + chain-link badge when minted on chain. Hover or focus any medallion to see a tooltip that names its status in words (Minted on-chain, Expiring in N days, Expired, Not yet on-chain) and describes what the stamp does. The persistent compact score sits in the shell chrome, top-left.",
       },
     },
   },
@@ -67,7 +68,7 @@ export const States: Story = {
     docs: {
       description: {
         story:
-          "One medallion of each state, side by side. Minted (Government ID) carries the emerald glow, the chain-link pip, and a settle animation. Mintable (Biometrics) shows an emerald outline invite, never gold. An off-chain verified stamp (Binance) is calm emerald glass. An expiring stamp (Civic, nine days) adds a small amber dot, the only amber on the medallion. An expired stamp (NFT) desaturates with a muted outline and reads inactive. An unverified stamp (Coinbase) is recessive. Everything but the expiring dot is emerald.",
+          "One medallion of each state, side by side. Minted (Government ID) carries the emerald glow and a static chain-link badge, top-right, with no animation so it reads at a glance. Mintable (Biometrics) shows an emerald outline invite, never gold. An off-chain verified stamp (Binance) is calm emerald glass. An expiring stamp (Civic, nine days) adds a small amber dot in the same top-right corner, the only amber on the medallion. An expired stamp (NFT) desaturates with a muted outline and reads inactive. An unverified stamp (Coinbase) is recessive. Hover any medallion to read its status in words. Everything but the expiring dot is emerald.",
       },
     },
   },

--- a/src/redesign/StampsWindow.stories.tsx
+++ b/src/redesign/StampsWindow.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { StampsWindow } from "./StampsWindow";
+import { PassportShell } from "./PassportShell";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS, SAMPLE_MEDALLION_STAMPS_PAGED } from "./storyFrame";
+
+/**
+ * StampsWindow - stamps as glass medallion plaques, grouped by category and
+ * paginated (never scrolled), composed inside the shell so the overlay rules
+ * (nothing outside the shell, no scrollbar, badges read as medallions) are
+ * visible. Both themes, no network.
+ */
+const meta: Meta<typeof StampsWindow> = {
+  title: "Redesign/Stamps Window",
+  component: StampsWindow,
+  parameters: { layout: "centered" },
+};
+export default meta;
+type Story = StoryObj<typeof StampsWindow>;
+
+const inShell = (node: React.ReactNode, size?: "full" | "mini" | "pill") => (
+  <ThemePair>
+    <PassportShell account={SAMPLE_ACCOUNT} size={size}>
+      {node}
+    </PassportShell>
+  </ThemePair>
+);
+
+export const FullGrid: Story = {
+  name: "Stamps / Full grid",
+  render: () =>
+    inShell(
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        pageSize={6}
+        onSelectStamp={() => undefined}
+        onVerify={() => undefined}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The medallion catalog: a mix of verified and unverified stamps, minted and mintable and off-chain. Each stamp is a glass badge with a conic rim, an embossed face, a points chip, and a corner on-chain pip (emerald minted, gold mintable, muted off-chain). Stamps group under tonal category headers. Tapping a badge fires onSelectStamp (the detail drawer is a later slice). A bottom-pinned emerald verify CTA matches the Score window's primary action.",
+      },
+    },
+  },
+};
+
+export const Paginated: Story = {
+  name: "Stamps / Paginated (two pages)",
+  render: () =>
+    inShell(
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS_PAGED}
+        onSelectStamp={() => undefined}
+        onVerify={() => undefined}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Ten stamps spill past one page, so the window paginates with dots and arrows. There is no scrollbar (an absolute SOP rule): overflow is split across pages, never scrolled. Each page regroups its own stamps under category headers.",
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  name: "Stamps / Empty",
+  render: () => inShell(<StampsWindow stamps={[]} onVerify={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "No stamps yet. A calm centered prompt with a single verify CTA, so the state is never a dead end. The shell height stays fixed so switching to a populated tab does not jump.",
+      },
+    },
+  },
+};
+
+export const Mini: Story = {
+  name: "Stamps / Mini",
+  render: () =>
+    inShell(<StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onSelectStamp={() => undefined} size="mini" />, "mini"),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The condensed half-size card: smaller medallions, one row per page, category headers dropped to save space. It shares the shell's fixed mini height.",
+      },
+    },
+  },
+};
+
+export const Pill: Story = {
+  name: "Stamps / Pill",
+  render: () =>
+    inShell(
+      <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onVerify={() => undefined} size="pill" />,
+      "pill"
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The single-row pill: a compact cluster of mini medallions, a stamp count, and one inline verify action. It summarizes rather than lists, so it never scrolls or paginates.",
+      },
+    },
+  },
+};

--- a/src/redesign/StampsWindow.stories.tsx
+++ b/src/redesign/StampsWindow.stories.tsx
@@ -1,8 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
-import { StampsWindow } from "./StampsWindow";
+import { StampsWindow, type Stamp } from "./StampsWindow";
 import { PassportShell } from "./PassportShell";
 import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS } from "./storyFrame";
+
+// One stamp of each state, all in a single category so they land on one page: a
+// side-by-side read of minted / mintable / unminted / expiring / expired /
+// unverified. Everything is emerald except the small amber "expiring" dot.
+const pick = (id: string): Stamp => ({
+  ...SAMPLE_MEDALLION_STAMPS.find((s) => s.id === id)!,
+  category: "Stamp states",
+});
+const STATE_STAMPS: Stamp[] = [
+  pick("HumanIdKyc"), // minted (emerald glow + chain pip + settle)
+  pick("Biometrics"), // mintable (emerald outline invite)
+  pick("Binance"), // unminted: verified, off-chain, calm
+  pick("Civic"), // expiring soon (small amber dot)
+  pick("NFT"), // expired (desaturated, muted)
+  pick("Coinbase"), // unverified (recessive)
+];
 
 /**
  * StampsWindow - the real Human Passport catalog as glass medallion plaques,
@@ -38,7 +54,20 @@ export const FullGrid: Story = {
     docs: {
       description: {
         story:
-          "The real catalog, navigated by category. The segmented control at the top carries the three real Passport categories (Physical Verification, Blockchain Networks and Activities, Web2 Platforms & Services), each with a verified/total count; the active category name shows below it. Each stamp is a glass medallion with its real platform icon (currentColor, so it adapts to both themes), a points chip, a corner on-chain pip (emerald minted, gold mintable, muted off-chain), and a compact expiry chip. The persistent compact score sits in the shell chrome, top-left.",
+          "The real catalog, navigated by category. The segmented control at the top carries the three real Passport categories (Physical Verification, Blockchain Networks and Activities, Web2 Platforms & Services), each with a verified/total count; the active category name shows below it. Each medallion is now pared to icon + name + points, and its state is carried by the medallion itself: a calm emerald glass when verified off-chain, an emerald outline when mintable, and an emerald glow + chain-link pip + a subtle settle when minted on chain. Hover or focus any medallion to see a tooltip describing what the stamp does. The persistent compact score sits in the shell chrome, top-left.",
+      },
+    },
+  },
+};
+
+export const States: Story = {
+  name: "Stamps / Stamp states",
+  render: () => inShell(<StampsWindow stamps={STATE_STAMPS} onSelectStamp={() => undefined} onVerify={() => undefined} />),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "One medallion of each state, side by side. Minted (Government ID) carries the emerald glow, the chain-link pip, and a settle animation. Mintable (Biometrics) shows an emerald outline invite, never gold. An off-chain verified stamp (Binance) is calm emerald glass. An expiring stamp (Civic, nine days) adds a small amber dot, the only amber on the medallion. An expired stamp (NFT) desaturates with a muted outline and reads inactive. An unverified stamp (Coinbase) is recessive. Everything but the expiring dot is emerald.",
       },
     },
   },
@@ -80,7 +109,7 @@ export const Expired: Story = {
     docs: {
       description: {
         story:
-          "Expiry reads on the grid. Each stamp shows a compact expiry chip: neutral days remaining when healthy, amber when expiring soon, and an expired stamp (here the NFT credential) desaturates and reads Expired. Every stamp expires as a whole; the drawer states the full 'Valid for N days' / 'Expires {date}' / 'Expired' copy.",
+          "Expiry reads on the grid without a chip. A stamp expiring soon carries a small amber dot in the corner (the only amber on the medallion), while an expired stamp (here the NFT credential) desaturates with a muted outline and reads inactive. The full validity copy ('Valid for N days' / 'Expires {date}' / 'Expired') moves to the drawer, where it lives behind the header timer's tooltip.",
       },
     },
   },

--- a/src/redesign/StampsWindow.stories.tsx
+++ b/src/redesign/StampsWindow.stories.tsx
@@ -2,13 +2,14 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { StampsWindow } from "./StampsWindow";
 import { PassportShell } from "./PassportShell";
-import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS, SAMPLE_MEDALLION_STAMPS_PAGED } from "./storyFrame";
+import { ThemePair, SAMPLE_ACCOUNT, SAMPLE_MEDALLION_STAMPS } from "./storyFrame";
 
 /**
- * StampsWindow - stamps as glass medallion plaques, grouped by category and
- * paginated (never scrolled), composed inside the shell so the overlay rules
- * (nothing outside the shell, no scrollbar, badges read as medallions) are
- * visible. Both themes, no network.
+ * StampsWindow - the real Human Passport catalog as glass medallion plaques,
+ * navigated BY CATEGORY (a segmented control of the real Passport categories),
+ * paginated within a category and never scrolled. Composed inside the shell so
+ * the overlay rules (nothing outside the shell, no scrollbar, real SVG icons,
+ * persistent score in the chrome) are visible. Both themes, no network.
  */
 const meta: Meta<typeof StampsWindow> = {
   title: "Redesign/Stamps Window",
@@ -18,41 +19,38 @@ const meta: Meta<typeof StampsWindow> = {
 export default meta;
 type Story = StoryObj<typeof StampsWindow>;
 
+// The shell carries the persistent compact score (top-left) on every window.
 const inShell = (node: React.ReactNode, size?: "full" | "mini" | "pill") => (
   <ThemePair>
-    <PassportShell account={SAMPLE_ACCOUNT} size={size}>
+    <PassportShell account={SAMPLE_ACCOUNT} size={size} score={24} threshold={20} onScoreClick={() => undefined}>
       {node}
     </PassportShell>
   </ThemePair>
 );
 
 export const FullGrid: Story = {
-  name: "Stamps / Full grid",
+  name: "Stamps / Full grid (category nav)",
   render: () =>
     inShell(
-      <StampsWindow
-        stamps={SAMPLE_MEDALLION_STAMPS}
-        pageSize={6}
-        onSelectStamp={() => undefined}
-        onVerify={() => undefined}
-      />
+      <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onSelectStamp={() => undefined} onVerify={() => undefined} />
     ),
   parameters: {
     docs: {
       description: {
         story:
-          "The medallion catalog: a mix of verified and unverified stamps, minted and mintable and off-chain. Each stamp is a glass badge with a conic rim, an embossed face, a points chip, and a corner on-chain pip (emerald minted, gold mintable, muted off-chain). Stamps group under tonal category headers. Tapping a badge fires onSelectStamp (the detail drawer is a later slice). A bottom-pinned emerald verify CTA matches the Score window's primary action.",
+          "The real catalog, navigated by category. The segmented control at the top carries the three real Passport categories (Physical Verification, Blockchain Networks and Activities, Web2 Platforms & Services), each with a verified/total count; the active category name shows below it. Each stamp is a glass medallion with its real platform icon (currentColor, so it adapts to both themes), a points chip, a corner on-chain pip (emerald minted, gold mintable, muted off-chain), and a compact expiry chip. The persistent compact score sits in the shell chrome, top-left.",
       },
     },
   },
 };
 
 export const Paginated: Story = {
-  name: "Stamps / Paginated (two pages)",
+  name: "Stamps / Within-category pagination",
   render: () =>
     inShell(
       <StampsWindow
-        stamps={SAMPLE_MEDALLION_STAMPS_PAGED}
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        initialCategory="Blockchain Networks and Activities"
         onSelectStamp={() => undefined}
         onVerify={() => undefined}
       />
@@ -61,7 +59,28 @@ export const Paginated: Story = {
     docs: {
       description: {
         story:
-          "Ten stamps spill past one page, so the window paginates with dots and arrows. There is no scrollbar (an absolute SOP rule): overflow is split across pages, never scrolled. Each page regroups its own stamps under category headers.",
+          "The Blockchain category holds twelve stamps, so it spills past one page and paginates with dots and arrows WITHIN the category. There is no scrollbar (an absolute SOP rule): overflow is split across pages, never scrolled. Switching category resets to its first page.",
+      },
+    },
+  },
+};
+
+export const Expired: Story = {
+  name: "Stamps / Expiring and expired",
+  render: () =>
+    inShell(
+      <StampsWindow
+        stamps={SAMPLE_MEDALLION_STAMPS}
+        initialCategory="Blockchain Networks and Activities"
+        onSelectStamp={() => undefined}
+        onVerify={() => undefined}
+      />
+    ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Expiry reads on the grid. Each stamp shows a compact expiry chip: neutral days remaining when healthy, amber when expiring soon, and an expired stamp (here the NFT credential) desaturates and reads Expired. Every stamp expires as a whole; the drawer states the full 'Valid for N days' / 'Expires {date}' / 'Expired' copy.",
       },
     },
   },
@@ -88,7 +107,7 @@ export const Mini: Story = {
     docs: {
       description: {
         story:
-          "The condensed half-size card: smaller medallions, one row per page, category headers dropped to save space. It shares the shell's fixed mini height.",
+          "The condensed half-size card: smaller medallions with their real icons, one flat paged row, category tabs dropped to save space. It shares the shell's fixed mini height and keeps the persistent score.",
       },
     },
   },
@@ -96,11 +115,7 @@ export const Mini: Story = {
 
 export const Pill: Story = {
   name: "Stamps / Pill",
-  render: () =>
-    inShell(
-      <StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onVerify={() => undefined} size="pill" />,
-      "pill"
-    ),
+  render: () => inShell(<StampsWindow stamps={SAMPLE_MEDALLION_STAMPS} onVerify={() => undefined} size="pill" />, "pill"),
   parameters: {
     docs: {
       description: {

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import styles from "./StampsWindow.module.css";
+import glass from "./glassTip.module.css";
+import { Tooltip } from "../components/Tooltip";
 import { CaretDownIcon, LinkIcon, PlusIcon, StarIcon } from "./icons";
 import { CATEGORY_ICONS } from "./stampIcons";
 import { formatExpiry } from "./expiry";
@@ -16,10 +18,12 @@ import type { ShellSize } from "./PassportShell";
  */
 
 /**
- * On-chain state of a stamp, carried by ONE signal (the corner pip):
- *  - "minted"   the stamp is recorded on-chain (emerald chain pip)
- *  - "mintable" the stamp can be minted on-chain (gold chain pip)
- *  - "none"     the stamp lives off-chain (muted, recessive pip)
+ * On-chain state of a stamp. Everything is emerald (no gold): the medallion's
+ * own treatment carries the state, not a colored chip.
+ *  - "minted"   notarized on-chain: emerald glow + a small chain-link pip + a
+ *               subtle settle animation. The "special" state.
+ *  - "mintable" verified but not notarized yet: emerald outline / glow invite.
+ *  - "none"     lives off-chain: a calm neutral-glass medallion.
  */
 export type StampOnchain = "minted" | "mintable" | "none";
 
@@ -51,6 +55,12 @@ export type Stamp = {
    * reverification after a year - the drawer reflects that copy.
    */
   isHumanId?: boolean;
+  /**
+   * Plain one-line description of what the stamp proves. Surfaced as the grid
+   * medallion's hover / focus tooltip (what the stamp does) and reused verbatim
+   * by the detail drawer. Omit to render the medallion with no tooltip.
+   */
+  description?: string;
 };
 
 export type StampsWindowProps = {
@@ -135,7 +145,7 @@ const deriveCategories = (items: Stamp[]): CategoryGroup[] => {
 };
 
 export type MedallionProps = {
-  /** The stamp whose face, on-chain pip, and points chip to render. */
+  /** The stamp whose face, state treatment, and points chip to render. */
   stamp: Stamp;
   /** Condensed ~half-size medallion (mini card). */
   compact?: boolean;
@@ -143,40 +153,44 @@ export type MedallionProps = {
    *  the total as its own text, so it renders the medallion WITHOUT the chip to
    *  avoid stating the points twice (one carrier per signal). */
   showPoints?: boolean;
-  /** Show the corner on-chain pip. Default true. The drawer header carries the
-   *  on-chain state in its status pill instead, so it drops the medallion pip. */
+  /** Show the corner status glyphs (the minted chain-link pip + the expiring dot).
+   *  Default true (grid). The drawer header carries on-chain state in its status
+   *  pill and expiry in its timer tooltip, so it passes false to drop both. */
   showPip?: boolean;
-  /** Show the compact expiry chip on the medallion (grid only). Default false;
-   *  the drawer header states expiry in its own line instead. The expired VISUAL
-   *  state (desaturation) applies regardless, so an expired stamp always reads. */
-  showExpiry?: boolean;
   /** Override the diameter (px). Sets --rd-med inline (wins over the size rule). */
   sizePx?: number;
 };
 
 /**
- * A single glass medallion: a rim + embossed face carrying the stamp icon, a
- * corner on-chain pip, and a points chip. Verified vs not is carried by the face
- * / rim tone; on-chain by the pip; points by the chip. One signal per meaning.
+ * A single glass medallion: a rim + embossed face carrying the stamp icon, with
+ * its on-brand STATE carried by the medallion itself (no chips):
+ *  - unverified: recessive, neutral rim.
+ *  - verified + off-chain ("none"): calm emerald-glass (unminted).
+ *  - verified + mintable: an emerald outline / glow invite (never gold).
+ *  - verified + minted: emerald glow + a small chain-link pip + a settle animation.
+ *  - expiring soon: a small amber dot in the corner (the ONLY amber here).
+ *  - expired: desaturated with a muted outline; reads inactive.
+ * Points ride on the chip; everything else is emerald. One carrier per meaning.
  *
  * Exported so the stamp detail drawer reuses the exact medallion look for its
- * header (a shared primitive, not a duplicated treatment). The header passes
- * showPoints/showPip false so the same on-chain + points signal is not stated
- * twice (§ no redundancy).
+ * header. The header passes showPoints/showPip false so on-chain + expiry are not
+ * stated twice (the drawer states them in its own pill + timer).
  */
 export const Medallion: React.FC<MedallionProps> = ({
   stamp,
   compact,
   showPoints = true,
   showPip = true,
-  showExpiry = false,
   sizePx,
 }) => {
   const expiry = formatExpiry(stamp.expirationDate);
   const expired = expiry?.state === "expired";
+  const soon = expiry?.state === "soon";
+  // Minted is the "special" state: an emerald glow + chain pip + a settle-in.
+  const minted = stamp.verified && stamp.onchain === "minted" && !expired;
   return (
     <span
-      className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
+      className={`${styles.medallion} ${compact ? styles.medallionSm : ""} ${minted ? styles.medallionMinted : ""}`}
       data-verified={stamp.verified ? "true" : "false"}
       data-onchain={stamp.onchain}
       data-expired={expired ? "true" : undefined}
@@ -187,22 +201,49 @@ export const Medallion: React.FC<MedallionProps> = ({
           {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
         </span>
       </span>
-      {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
-          to the chain (minted / mintable); "none" is a recessive muted disc. */}
-      {showPip ? (
+      {/* Minted chain-link pip: the single "notarized on chain" mark. Emerald only;
+          mintable / off-chain carry their state through the medallion treatment. */}
+      {showPip && minted ? (
         <span className={styles.pip} aria-hidden="true">
-          {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+          <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />
         </span>
       ) : null}
-      {/* Compact expiry chip (grid only): reads the SAME expiry the drawer states
-          in full, condensed to "88d" / "8d" / "Expired". One carrier per meaning. */}
-      {showExpiry && expiry ? (
-        <span className={styles.expiryChip} data-state={expiry.state} aria-hidden="true">
-          {expiry.short}
-        </span>
-      ) : null}
+      {/* Expiring-soon dot: the ONLY amber on the medallion, and a small indicator
+          only (never the whole face). Suppressed once expired (that reads muted). */}
+      {showPip && soon && !expired ? <span className={styles.expiringDot} aria-hidden="true" /> : null}
       {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
     </span>
+  );
+};
+
+/**
+ * One grid badge: the medallion + name, the whole thing a tap target. When the
+ * stamp carries a description it is wrapped in the portal glass Tooltip so hover
+ * / focus reveals WHAT the stamp does, readable in both themes and never clipped
+ * (the tooltip portals to the body, so it escapes the fixed shell bounds).
+ */
+const StampBadge: React.FC<{
+  stamp: Stamp;
+  compact?: boolean;
+  onSelect?: (id: string) => void;
+}> = ({ stamp, compact, onSelect }) => {
+  const btn = (
+    <button
+      type="button"
+      className={styles.badge}
+      onClick={() => onSelect?.(stamp.id)}
+      aria-label={stampLabel(stamp)}
+    >
+      <Medallion stamp={stamp} compact={compact} />
+      <span className={styles.name}>{stamp.name}</span>
+    </button>
+  );
+  return stamp.description ? (
+    <Tooltip content={stamp.description} placement="top" className={glass.tip}>
+      {btn}
+    </Tooltip>
+  ) : (
+    btn
   );
 };
 
@@ -448,16 +489,7 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
         <div className={styles.pages}>
           <div className={styles.grid}>
             {pageStamps.map((s) => (
-              <button
-                type="button"
-                key={s.id}
-                className={styles.badge}
-                onClick={() => onSelectStamp?.(s.id)}
-                aria-label={stampLabel(s)}
-              >
-                <Medallion stamp={s} compact showExpiry />
-                <span className={styles.name}>{s.name}</span>
-              </button>
+              <StampBadge key={s.id} stamp={s} compact onSelect={onSelectStamp} />
             ))}
           </div>
         </div>
@@ -492,16 +524,7 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
       <div className={styles.pages}>
         <div className={styles.grid}>
           {pageStamps.map((s) => (
-            <button
-              type="button"
-              key={s.id}
-              className={styles.badge}
-              onClick={() => onSelectStamp?.(s.id)}
-              aria-label={stampLabel(s)}
-            >
-              <Medallion stamp={s} showExpiry />
-              <span className={styles.name}>{s.name}</span>
-            </button>
+            <StampBadge key={s.id} stamp={s} onSelect={onSelectStamp} />
           ))}
         </div>
       </div>

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -101,20 +101,44 @@ export type StampsWindowProps = {
 // fixed shell height; mini keeps one short row.
 const DEFAULT_PAGE_SIZE: Record<ShellSize, number> = { full: 6, mini: 3, pill: 3 };
 
-const ONCHAIN_LABEL: Record<StampOnchain, string> = {
-  minted: "Minted on chain",
-  mintable: "Can be minted on chain",
-  none: "Off chain",
+/**
+ * Short, honest tab labels for the real (long) Passport category names. The tab
+ * carries the short name + count so the navigation is legible at 300px; the
+ * verbatim full name still reads in the category heading below and in every tab's
+ * accessible label. Falls back to the first word of any unmapped category.
+ */
+const SHORT_CATEGORY: Record<string, string> = {
+  "Physical Verification": "Physical",
+  "Blockchain Networks and Activities": "Blockchain",
+  "Web2 Platforms & Services": "Web2",
 };
+const shortCategory = (c: string): string => SHORT_CATEGORY[c] ?? c.split(/\s+/)[0];
 
 /** Plain-language points phrase for the accessible name (earned vs available). */
 const pointsPhrase = (s: Stamp) =>
   s.verified ? `${s.points} points earned` : `${s.points} points available`;
 
+/**
+ * The stamp's STATUS in plain words, the same phrase shown in the medallion
+ * tooltip and folded into the accessible name so every state reads at a glance
+ * AND is stated in words (design-sop states-are-legible + one-signal-per-meaning).
+ * Precedence puts the time-sensitive states first (expired, then expiring), so a
+ * minted-but-expiring stamp surfaces the actionable "Expiring in N days" while its
+ * corner still carries the minted chain mark. The amber corner dot means exactly
+ * this "expiring" state, and here it is named.
+ */
+const statusPhrase = (s: Stamp): string => {
+  if (!s.verified) return "Not verified yet";
+  const expiry = formatExpiry(s.expirationDate);
+  if (expiry?.state === "expired") return "Expired";
+  if (expiry?.state === "soon") return `Expiring in ${expiry.days} ${expiry.days === 1 ? "day" : "days"}`;
+  if (s.onchain === "minted") return "Minted on-chain";
+  if (s.onchain === "mintable") return "Not yet on-chain";
+  return "Verified";
+};
+
 const stampLabel = (s: Stamp) =>
-  `${s.name}. ${pointsPhrase(s)}. ${s.verified ? "Verified" : "Not verified yet"}. ${
-    ONCHAIN_LABEL[s.onchain]
-  }. Open stamp.`;
+  `${s.name}. ${pointsPhrase(s)}. ${statusPhrase(s)}. Open stamp.`;
 
 /** Split a flat list into fixed-size pages. */
 const paginate = <T,>(items: T[], per: number): T[][] => {
@@ -167,10 +191,13 @@ export type MedallionProps = {
  *  - unverified: recessive, neutral rim.
  *  - verified + off-chain ("none"): calm emerald-glass (unminted).
  *  - verified + mintable: an emerald outline / glow invite (never gold).
- *  - verified + minted: emerald glow + a small chain-link pip + a settle animation.
- *  - expiring soon: a small amber dot in the corner (the ONLY amber here).
+ *  - verified + minted: emerald glow + a static chain-link badge (top-right). No
+ *    animation: the mark is self-evident and reads at a glance, not on a settle.
+ *  - expiring soon: a small amber dot in the SAME top-right corner (the ONLY amber
+ *    here). The tooltip names it "Expiring in N days".
  *  - expired: desaturated with a muted outline; reads inactive.
- * Points ride on the chip; everything else is emerald. One carrier per meaning.
+ * Points ride on the chip; everything else is emerald. One carrier per meaning,
+ * and every status indicator lives in ONE place: the top-right corner.
  *
  * Exported so the stamp detail drawer reuses the exact medallion look for its
  * header. The header passes showPoints/showPip false so on-chain + expiry are not
@@ -186,11 +213,11 @@ export const Medallion: React.FC<MedallionProps> = ({
   const expiry = formatExpiry(stamp.expirationDate);
   const expired = expiry?.state === "expired";
   const soon = expiry?.state === "soon";
-  // Minted is the "special" state: an emerald glow + chain pip + a settle-in.
+  // Minted is the "special" state: a static emerald chain-link badge + glow ring.
   const minted = stamp.verified && stamp.onchain === "minted" && !expired;
   return (
     <span
-      className={`${styles.medallion} ${compact ? styles.medallionSm : ""} ${minted ? styles.medallionMinted : ""}`}
+      className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
       data-verified={stamp.verified ? "true" : "false"}
       data-onchain={stamp.onchain}
       data-expired={expired ? "true" : undefined}
@@ -201,49 +228,59 @@ export const Medallion: React.FC<MedallionProps> = ({
           {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
         </span>
       </span>
-      {/* Minted chain-link pip: the single "notarized on chain" mark. Emerald only;
-          mintable / off-chain carry their state through the medallion treatment. */}
+      {/* Top-right corner = the ONE indicator slot. Minted shows the static
+          chain-link badge (the "notarized on chain" mark). Otherwise an expiring
+          stamp shows the amber dot in the same corner. They never both render, so
+          the corner is never crowded and there is no top-left indicator. */}
       {showPip && minted ? (
         <span className={styles.pip} aria-hidden="true">
           <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />
         </span>
+      ) : showPip && soon && !expired ? (
+        <span className={styles.expiringDot} aria-hidden="true" />
       ) : null}
-      {/* Expiring-soon dot: the ONLY amber on the medallion, and a small indicator
-          only (never the whole face). Suppressed once expired (that reads muted). */}
-      {showPip && soon && !expired ? <span className={styles.expiringDot} aria-hidden="true" /> : null}
       {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
     </span>
   );
 };
 
 /**
- * One grid badge: the medallion + name, the whole thing a tap target. When the
- * stamp carries a description it is wrapped in the portal glass Tooltip so hover
- * / focus reveals WHAT the stamp does, readable in both themes and never clipped
- * (the tooltip portals to the body, so it escapes the fixed shell bounds).
+ * One grid badge: the medallion + name, the whole thing a tap target. Wrapped in
+ * the portal glass Tooltip so hover / focus reveals the stamp's STATUS in words
+ * (Minted on-chain / Expiring in N days / Expired / Not yet on-chain / Not
+ * verified yet) plus WHAT the stamp does. The tooltip portals to document.body,
+ * so it escapes the fixed shell bounds, is never occluded by the chrome, and
+ * edge-flips against the viewport (design-sop states-are-legible + overlay
+ * layering). Readable in both themes.
  */
 const StampBadge: React.FC<{
   stamp: Stamp;
   compact?: boolean;
   onSelect?: (id: string) => void;
 }> = ({ stamp, compact, onSelect }) => {
-  const btn = (
-    <button
-      type="button"
-      className={styles.badge}
-      onClick={() => onSelect?.(stamp.id)}
-      aria-label={stampLabel(stamp)}
-    >
-      <Medallion stamp={stamp} compact={compact} />
-      <span className={styles.name}>{stamp.name}</span>
-    </button>
+  const tip = (
+    <>
+      <strong>{statusPhrase(stamp)}</strong>
+      {stamp.description ? (
+        <>
+          <br />
+          {stamp.description}
+        </>
+      ) : null}
+    </>
   );
-  return stamp.description ? (
-    <Tooltip content={stamp.description} placement="top" className={glass.tip}>
-      {btn}
+  return (
+    <Tooltip content={tip} placement="top" className={glass.tip}>
+      <button
+        type="button"
+        className={styles.badge}
+        onClick={() => onSelect?.(stamp.id)}
+        aria-label={stampLabel(stamp)}
+      >
+        <Medallion stamp={stamp} compact={compact} />
+        <span className={styles.name}>{stamp.name}</span>
+      </button>
     </Tooltip>
-  ) : (
-    btn
   );
 };
 
@@ -307,10 +344,11 @@ const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => 
 
 /**
  * Category selector (segmented control): one segment per real Passport category.
- * Each segment carries the category glyph + a verified/total count; the active
- * segment is highlighted. This is the PRIMARY navigation - it switches the whole
- * grid to that category (no blind whole-catalog paging). The full verbatim name
- * rides on the active-category heading below + every segment's accessible label.
+ * Each segment is a NAMED tab (short category name) + its verified/total count;
+ * the active segment is highlighted. This is the PRIMARY navigation - it switches
+ * the whole grid to that category (no blind whole-catalog paging, no ambiguous
+ * star + number pill). The verbatim full name rides on the active-category
+ * heading below and on every segment's accessible label.
  */
 const CategoryTabs: React.FC<{
   groups: CategoryGroup[];
@@ -329,9 +367,7 @@ const CategoryTabs: React.FC<{
         title={`${g.category}. ${g.verified} of ${g.stamps.length} verified.`}
         aria-label={`${g.category}. ${g.verified} of ${g.stamps.length} verified.`}
       >
-        <span className={styles.tabIcon} aria-hidden="true">
-          {CATEGORY_ICONS[g.category] ?? <StarIcon size={18} strokeWidth={1.6} />}
-        </span>
+        <span className={styles.tabName}>{shortCategory(g.category)}</span>
         <span className={styles.tabCount}>
           {g.verified}/{g.stamps.length}
         </span>
@@ -510,13 +546,18 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
 
       {activeGroup ? (
         <div className={styles.catBar}>
-          {/* Verbatim category name (single line; full name in title + tab a11y
-              labels), plus its verified/total count. */}
+          {/* Verbatim category name (single line) led by its glyph. The active
+              category's own count already rides on its highlighted tab, so here
+              we carry the OVERALL passport progress as a plainly labeled summary
+              ("N of M verified"), never a bare star + number. */}
           <span className={styles.catName} title={activeGroup.category}>
-            {activeGroup.category}
+            <span className={styles.catGlyph} aria-hidden="true">
+              {CATEGORY_ICONS[activeGroup.category] ?? <StarIcon size={16} strokeWidth={1.6} />}
+            </span>
+            <span className={styles.catNameText}>{activeGroup.category}</span>
           </span>
-          <span className={styles.count}>
-            {activeGroup.verified}/{activeGroup.stamps.length}
+          <span className={styles.catSummary}>
+            {verifiedCount} of {stamps.length} verified
           </span>
         </div>
       ) : null}

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -101,16 +101,44 @@ const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stam
   return order.map((category) => ({ category, stamps: map.get(category)! }));
 };
 
+export type MedallionProps = {
+  /** The stamp whose face, on-chain pip, and points chip to render. */
+  stamp: Stamp;
+  /** Condensed ~half-size medallion (mini card). */
+  compact?: boolean;
+  /** Show the overlapping points chip. Default true. The drawer header carries
+   *  the total as its own text, so it renders the medallion WITHOUT the chip to
+   *  avoid stating the points twice (one carrier per signal). */
+  showPoints?: boolean;
+  /** Show the corner on-chain pip. Default true. The drawer header carries the
+   *  on-chain state in its status pill instead, so it drops the medallion pip. */
+  showPip?: boolean;
+  /** Override the diameter (px). Sets --rd-med inline (wins over the size rule). */
+  sizePx?: number;
+};
+
 /**
  * A single glass medallion: a rim + embossed face carrying the stamp icon, a
  * corner on-chain pip, and a points chip. Verified vs not is carried by the face
  * / rim tone; on-chain by the pip; points by the chip. One signal per meaning.
+ *
+ * Exported so the stamp detail drawer reuses the exact medallion look for its
+ * header (a shared primitive, not a duplicated treatment). The header passes
+ * showPoints/showPip false so the same on-chain + points signal is not stated
+ * twice (§ no redundancy).
  */
-const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compact }) => (
+export const Medallion: React.FC<MedallionProps> = ({
+  stamp,
+  compact,
+  showPoints = true,
+  showPip = true,
+  sizePx,
+}) => (
   <span
     className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
     data-verified={stamp.verified ? "true" : "false"}
     data-onchain={stamp.onchain}
+    style={sizePx ? ({ "--rd-med": `${sizePx}px` } as React.CSSProperties) : undefined}
   >
     <span className={styles.face}>
       <span className={styles.glyph} aria-hidden="true">
@@ -119,10 +147,12 @@ const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compa
     </span>
     {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
         to the chain (minted / mintable); "none" is a recessive muted disc. */}
-    <span className={styles.pip} aria-hidden="true">
-      {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
-    </span>
-    <span className={styles.points}>+{stamp.points}</span>
+    {showPip ? (
+      <span className={styles.pip} aria-hidden="true">
+        {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+      </span>
+    ) : null}
+    {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
   </span>
 );
 

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -1,0 +1,365 @@
+import React, { useMemo, useState } from "react";
+import styles from "./StampsWindow.module.css";
+import { CaretDownIcon, LinkIcon, PlusIcon, StarIcon } from "./icons";
+import { useReducedMotion } from "./hooks";
+import type { ShellSize } from "./PassportShell";
+
+/**
+ * On-chain state of a stamp, carried by ONE signal (the corner pip):
+ *  - "minted"   the stamp is recorded on-chain (emerald chain pip)
+ *  - "mintable" the stamp can be minted on-chain (gold chain pip)
+ *  - "none"     the stamp lives off-chain (muted, recessive pip)
+ */
+export type StampOnchain = "minted" | "mintable" | "none";
+
+export type Stamp = {
+  /** Stable id passed back through onSelectStamp. */
+  id: string;
+  /** Short stamp name, e.g. "Government ID". */
+  name: string;
+  /** Grouping label, e.g. "Identity" / "Biometrics" / "Social". */
+  category: string;
+  /** Points this stamp contributes to the score (earned when verified). */
+  points: number;
+  /** Whether the credential is verified (earned) or still available to add. */
+  verified: boolean;
+  /** On-chain state. Drives the medallion's corner pip only (one signal). */
+  onchain: StampOnchain;
+  /** Optional badge face art (an emoji, an <img>, or an icon node). */
+  icon?: React.ReactNode;
+};
+
+export type StampsWindowProps = {
+  /** The stamps to show, grouped by category and paginated (never scrolled). */
+  stamps: Stamp[];
+  /** Tapping a badge fires this with the stamp id (the detail drawer is a later slice). */
+  onSelectStamp?: (stampId: string) => void;
+  /**
+   * The verify / add entry point (bottom-pinned primary CTA, consistent with the
+   * shell's "Add verifications"). Omit to drop the CTA entirely.
+   */
+  onVerify?: () => void;
+  /** Override the verify CTA label. */
+  verifyLabel?: string;
+  /** Badges per page before it paginates. Defaults to 6 (full) / 3 (mini). */
+  pageSize?: number;
+  /** Override the header label. Defaults to "Your stamps". */
+  headline?: string;
+  /** Empty-state message. Defaults to a plain "No stamps yet" line. */
+  emptyLabel?: string;
+  /**
+   * Interim loading state. Reuses the ScoreWindow ScoreLoader approach (a simple
+   * indeterminate emerald arc); it does NOT invent a new loader or pull Cryptex.
+   */
+  loading?: boolean;
+  /**
+   * Size variant, mirrors the shell's. Pass the SAME value you pass to
+   * PassportShell so the fixed height matches and the tab-switch never jumps.
+   */
+  size?: ShellSize;
+};
+
+// Kept small so a page never renders more medallion rows than the shell's fixed
+// height holds (each category becomes its own row, so few-item categories add up
+// fast). Stories that show a denser single page pass an explicit larger pageSize.
+const DEFAULT_PAGE_SIZE: Record<ShellSize, number> = { full: 4, mini: 3, pill: 3 };
+
+const ONCHAIN_LABEL: Record<StampOnchain, string> = {
+  minted: "Minted on chain",
+  mintable: "Can be minted on chain",
+  none: "Off chain",
+};
+
+/** Plain-language points phrase for the accessible name (earned vs available). */
+const pointsPhrase = (s: Stamp) =>
+  s.verified ? `${s.points} points earned` : `${s.points} points available`;
+
+const stampLabel = (s: Stamp) =>
+  `${s.name}. ${pointsPhrase(s)}. ${s.verified ? "Verified" : "Not verified yet"}. ${
+    ONCHAIN_LABEL[s.onchain]
+  }. Open stamp.`;
+
+/** Split a flat list into fixed-size pages. */
+const paginate = <T,>(items: T[], per: number): T[][] => {
+  if (per <= 0) return [items];
+  const pages: T[][] = [];
+  for (let i = 0; i < items.length; i += per) pages.push(items.slice(i, i + per));
+  return pages.length ? pages : [[]];
+};
+
+/** Group a page's stamps by category, preserving first-appearance order. */
+const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stamp[] }> => {
+  const order: string[] = [];
+  const map = new Map<string, Stamp[]>();
+  for (const s of items) {
+    if (!map.has(s.category)) {
+      map.set(s.category, []);
+      order.push(s.category);
+    }
+    map.get(s.category)!.push(s);
+  }
+  return order.map((category) => ({ category, stamps: map.get(category)! }));
+};
+
+/**
+ * A single glass medallion: a rim + embossed face carrying the stamp icon, a
+ * corner on-chain pip, and a points chip. Verified vs not is carried by the face
+ * / rim tone; on-chain by the pip; points by the chip. One signal per meaning.
+ */
+const Medallion: React.FC<{ stamp: Stamp; compact?: boolean }> = ({ stamp, compact }) => (
+  <span
+    className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
+    data-verified={stamp.verified ? "true" : "false"}
+    data-onchain={stamp.onchain}
+  >
+    <span className={styles.face}>
+      <span className={styles.glyph} aria-hidden="true">
+        {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
+      </span>
+    </span>
+    {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
+        to the chain (minted / mintable); "none" is a recessive muted disc. */}
+    <span className={styles.pip} aria-hidden="true">
+      {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+    </span>
+    <span className={styles.points}>+{stamp.points}</span>
+  </span>
+);
+
+/**
+ * Interim loader, mirroring ScoreWindow's ScoreLoader (a simple indeterminate
+ * emerald arc). Not a new loader, and NOT the Cryptex loader (see ScoreWindow /
+ * design-sop §7 reuse-shared-components): the shared loader is consumed as a
+ * dependency once installable, never vendored into this public repo.
+ */
+const StampsLoader: React.FC = () => {
+  const reduced = useReducedMotion();
+  return (
+    <div className={styles.loaderWrap} role="status" aria-label="Loading your stamps">
+      <svg width={44} height={44} viewBox="0 0 48 48" aria-hidden className={reduced ? undefined : styles.spin}>
+        <circle cx="24" cy="24" r="20" fill="none" stroke="rgba(var(--muted), 0.25)" strokeWidth="4" />
+        <path d="M24 4 a20 20 0 0 1 20 20" fill="none" stroke="rgb(var(--accent))" strokeWidth="4" strokeLinecap="round" />
+      </svg>
+    </div>
+  );
+};
+
+/** Reused pager: dots + arrows, never a scrollbar (matches the shell pager). */
+const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => void }> = ({
+  page,
+  pageCount,
+  onPage,
+}) => (
+  <div className={styles.pager} role="group" aria-label="Stamp pages">
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.max(0, page - 1))}
+      disabled={page === 0}
+      aria-label="Previous stamps"
+    >
+      <CaretDownIcon className={styles.pagerPrev} size={13} />
+    </button>
+    <span className={styles.pagerDots}>
+      {Array.from({ length: pageCount }).map((_, i) => (
+        <button
+          type="button"
+          key={i}
+          className={`${styles.pagerDot} ${i === page ? styles.pagerDotOn : ""}`}
+          onClick={() => onPage(i)}
+          aria-label={`Stamp page ${i + 1}`}
+          aria-current={i === page ? "true" : undefined}
+        />
+      ))}
+    </span>
+    <button
+      type="button"
+      className={styles.pagerArrow}
+      onClick={() => onPage(Math.min(pageCount - 1, page + 1))}
+      disabled={page === pageCount - 1}
+      aria-label="More stamps"
+    >
+      <CaretDownIcon className={styles.pagerNext} size={13} />
+    </button>
+  </div>
+);
+
+/**
+ * StampsWindow - the medallion catalog, rendered INSIDE PassportShell like the
+ * Score window. Stamps are glass plaques grouped by category, paginated and never
+ * scrolled (§4 / §Windows). Presentational: props only, no data hooks, both-theme
+ * legible, reduced-motion aware. Tapping a badge fires onSelectStamp; the detail
+ * drawer is a later slice.
+ */
+export const StampsWindow: React.FC<StampsWindowProps> = ({
+  stamps,
+  onSelectStamp,
+  onVerify,
+  verifyLabel,
+  pageSize,
+  headline,
+  emptyLabel,
+  loading = false,
+  size = "full",
+}) => {
+  const [page, setPage] = useState(0);
+  const per = pageSize ?? DEFAULT_PAGE_SIZE[size];
+  const compact = size !== "full";
+
+  const pages = useMemo(() => paginate(stamps, per), [stamps, per]);
+  const pageCount = pages.length;
+  const current = Math.min(page, pageCount - 1);
+  const pageStamps = pages[current] ?? [];
+  const groups = useMemo(() => groupByCategory(pageStamps), [pageStamps]);
+
+  const verifiedCount = useMemo(() => stamps.filter((s) => s.verified).length, [stamps]);
+
+  const winClass = `${styles.window} ${size === "mini" ? styles.miniWin : ""} ${
+    size === "pill" ? styles.pillWin : ""
+  }`;
+
+  // ---- pill: one short status row. Up to three mini medallions, a count, and
+  // one compact action. No category headers, no pager (the pill summarizes). ----
+  if (size === "pill") {
+    // Two preview medallions keep the single row from crowding the count + action
+    // at the 300px pill width (the third would push the label into an ellipsis).
+    const preview = stamps.slice(0, 2);
+    return (
+      <div className={winClass}>
+        {loading ? (
+          <>
+            <StampsLoader />
+            <span className={styles.pillText}>Loading your stamps</span>
+          </>
+        ) : (
+          <>
+            <span className={styles.pillStack} aria-hidden="true">
+              {preview.map((s) => (
+                <Medallion key={s.id} stamp={s} compact />
+              ))}
+            </span>
+            <span className={styles.pillText}>
+              {verifiedCount}/{stamps.length} verified
+            </span>
+            {onVerify ? (
+              <button type="button" className={`${styles.cta} ${styles.ctaInline}`} onClick={onVerify}>
+                <span className={styles.ctaIcon}>
+                  <PlusIcon size={14} strokeWidth={2} />
+                </span>
+                <span className={styles.ctaLabel}>{verifyLabel ?? "Verify"}</span>
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className={winClass}>
+        <div className={styles.head}>
+          <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        </div>
+        <div className={styles.center}>
+          <StampsLoader />
+          <p className={styles.emptyText}>Loading your stamps</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!stamps.length) {
+    return (
+      <div className={winClass}>
+        <div className={styles.head}>
+          <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        </div>
+        <div className={styles.center}>
+          <span className={styles.emptyMark} aria-hidden="true">
+            <StarIcon size={22} strokeWidth={1.6} />
+          </span>
+          <p className={styles.emptyText}>{emptyLabel ?? "No stamps yet. Verify one to start your passport."}</p>
+        </div>
+        {onVerify ? (
+          <button type="button" className={styles.cta} onClick={onVerify}>
+            <span className={styles.ctaIcon}>
+              <PlusIcon size={15} strokeWidth={2} />
+            </span>
+            <span className={styles.ctaLabel}>{verifyLabel ?? "Verify a stamp"}</span>
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className={winClass}>
+      <p className={styles.srOnly} aria-live="polite">
+        {stamps.length} stamps, {verifiedCount} verified. Page {current + 1} of {pageCount}.
+      </p>
+
+      <div className={styles.head}>
+        <span className={styles.title}>{headline ?? "Your stamps"}</span>
+        <span className={styles.count}>
+          {verifiedCount}/{stamps.length} verified
+        </span>
+      </div>
+
+      <div className={styles.pages}>
+        {compact ? (
+          // mini stays simpler: one flat grid, no category headers, so the
+          // half-size card keeps to a single medallion row per page.
+          <div className={styles.grid}>
+            {pageStamps.map((s) => (
+              <button
+                type="button"
+                key={s.id}
+                className={styles.badge}
+                onClick={() => onSelectStamp?.(s.id)}
+                aria-label={stampLabel(s)}
+              >
+                <Medallion stamp={s} compact />
+                <span className={styles.name}>{s.name}</span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          groups.map((group) => (
+            <div className={styles.group} key={group.category}>
+              {/* Category header: tonal text + space, no hard line (§ no-hard-lines). */}
+              <div className={styles.catHead}>{group.category}</div>
+              <div className={styles.grid}>
+                {group.stamps.map((s) => (
+                  <button
+                    type="button"
+                    key={s.id}
+                    className={styles.badge}
+                    onClick={() => onSelectStamp?.(s.id)}
+                    aria-label={stampLabel(s)}
+                  >
+                    <Medallion stamp={s} />
+                    <span className={styles.name}>{s.name}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+
+      {/* Bottom-pinned verify entry, consistent with the shell's primary CTA. mini
+          stays simpler and drops it to keep the half-size card uncluttered. */}
+      {onVerify && !compact ? (
+        <button type="button" className={styles.cta} onClick={onVerify}>
+          <span className={styles.ctaIcon}>
+            <PlusIcon size={15} strokeWidth={2} />
+          </span>
+          <span className={styles.ctaLabel}>{verifyLabel ?? "Verify more stamps"}</span>
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/src/redesign/StampsWindow.tsx
+++ b/src/redesign/StampsWindow.tsx
@@ -1,8 +1,19 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import styles from "./StampsWindow.module.css";
 import { CaretDownIcon, LinkIcon, PlusIcon, StarIcon } from "./icons";
+import { CATEGORY_ICONS } from "./stampIcons";
+import { formatExpiry } from "./expiry";
 import { useReducedMotion } from "./hooks";
 import type { ShellSize } from "./PassportShell";
+
+/*
+ * Real data model note: in production the presentational shape below is the JOIN
+ * of two endpoints, keyed by credential id. `/embed/stamps/metadata` supplies the
+ * icon, weight, category, credential ids and descriptions; `/embed/score` supplies
+ * the per-stamp `expiration_date`, `dedup`, and earned `score`. The catalog + the
+ * score are merged into these `Stamp` / `StampDetail` props before render; the
+ * components here take that joined shape and never fetch.
+ */
 
 /**
  * On-chain state of a stamp, carried by ONE signal (the corner pip):
@@ -27,6 +38,19 @@ export type Stamp = {
   onchain: StampOnchain;
   /** Optional badge face art (an emoji, an <img>, or an icon node). */
   icon?: React.ReactNode;
+  /**
+   * ISO date this stamp expires. Every stamp expires as a whole (the score
+   * endpoint carries a per-stamp expiration date; default lifetime is 90 days).
+   * Drives the "Valid for N days" / "Expires {date}" / "Expired" copy + the
+   * expired visual state. Omit for a stamp that is not yet verified.
+   */
+  expirationDate?: string;
+  /**
+   * True when this stamp is a Human ID SBT (Government ID, Phone, Biometrics,
+   * Proof of Clean Hands). Such stamps auto-renew after 90 days, with full
+   * reverification after a year - the drawer reflects that copy.
+   */
+  isHumanId?: boolean;
 };
 
 export type StampsWindowProps = {
@@ -41,8 +65,10 @@ export type StampsWindowProps = {
   onVerify?: () => void;
   /** Override the verify CTA label. */
   verifyLabel?: string;
-  /** Badges per page before it paginates. Defaults to 6 (full) / 3 (mini). */
+  /** Badges per category page before it paginates. Defaults to 6 (full) / 3 (mini). */
   pageSize?: number;
+  /** Category selected on first paint (by verbatim name). Defaults to the first. */
+  initialCategory?: string;
   /** Override the header label. Defaults to "Your stamps". */
   headline?: string;
   /** Empty-state message. Defaults to a plain "No stamps yet" line. */
@@ -59,10 +85,11 @@ export type StampsWindowProps = {
   size?: ShellSize;
 };
 
-// Kept small so a page never renders more medallion rows than the shell's fixed
-// height holds (each category becomes its own row, so few-item categories add up
-// fast). Stories that show a denser single page pass an explicit larger pageSize.
-const DEFAULT_PAGE_SIZE: Record<ShellSize, number> = { full: 4, mini: 3, pill: 3 };
+// Badges per page WITHIN a category before it paginates. The primary nav is the
+// category selector; paging is the secondary overflow within one category, never
+// a scrollbar. Full fits two rows of three under the tabs + heading + CTA in the
+// fixed shell height; mini keeps one short row.
+const DEFAULT_PAGE_SIZE: Record<ShellSize, number> = { full: 6, mini: 3, pill: 3 };
 
 const ONCHAIN_LABEL: Record<StampOnchain, string> = {
   minted: "Minted on chain",
@@ -87,8 +114,11 @@ const paginate = <T,>(items: T[], per: number): T[][] => {
   return pages.length ? pages : [[]];
 };
 
-/** Group a page's stamps by category, preserving first-appearance order. */
-const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stamp[] }> => {
+type CategoryGroup = { category: string; stamps: Stamp[]; verified: number };
+
+/** Group stamps by category, preserving first-appearance order, with a per-category
+ *  verified count for the tab badge (e.g. "5/7"). */
+const deriveCategories = (items: Stamp[]): CategoryGroup[] => {
   const order: string[] = [];
   const map = new Map<string, Stamp[]>();
   for (const s of items) {
@@ -98,7 +128,10 @@ const groupByCategory = (items: Stamp[]): Array<{ category: string; stamps: Stam
     }
     map.get(s.category)!.push(s);
   }
-  return order.map((category) => ({ category, stamps: map.get(category)! }));
+  return order.map((category) => {
+    const stamps = map.get(category)!;
+    return { category, stamps, verified: stamps.filter((s) => s.verified).length };
+  });
 };
 
 export type MedallionProps = {
@@ -113,6 +146,10 @@ export type MedallionProps = {
   /** Show the corner on-chain pip. Default true. The drawer header carries the
    *  on-chain state in its status pill instead, so it drops the medallion pip. */
   showPip?: boolean;
+  /** Show the compact expiry chip on the medallion (grid only). Default false;
+   *  the drawer header states expiry in its own line instead. The expired VISUAL
+   *  state (desaturation) applies regardless, so an expired stamp always reads. */
+  showExpiry?: boolean;
   /** Override the diameter (px). Sets --rd-med inline (wins over the size rule). */
   sizePx?: number;
 };
@@ -132,29 +169,42 @@ export const Medallion: React.FC<MedallionProps> = ({
   compact,
   showPoints = true,
   showPip = true,
+  showExpiry = false,
   sizePx,
-}) => (
-  <span
-    className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
-    data-verified={stamp.verified ? "true" : "false"}
-    data-onchain={stamp.onchain}
-    style={sizePx ? ({ "--rd-med": `${sizePx}px` } as React.CSSProperties) : undefined}
-  >
-    <span className={styles.face}>
-      <span className={styles.glyph} aria-hidden="true">
-        {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
+}) => {
+  const expiry = formatExpiry(stamp.expirationDate);
+  const expired = expiry?.state === "expired";
+  return (
+    <span
+      className={`${styles.medallion} ${compact ? styles.medallionSm : ""}`}
+      data-verified={stamp.verified ? "true" : "false"}
+      data-onchain={stamp.onchain}
+      data-expired={expired ? "true" : undefined}
+      style={sizePx ? ({ "--rd-med": `${sizePx}px` } as React.CSSProperties) : undefined}
+    >
+      <span className={styles.face}>
+        <span className={styles.glyph} aria-hidden="true">
+          {stamp.icon ?? <StarIcon size={compact ? 15 : 20} strokeWidth={1.6} />}
+        </span>
       </span>
+      {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
+          to the chain (minted / mintable); "none" is a recessive muted disc. */}
+      {showPip ? (
+        <span className={styles.pip} aria-hidden="true">
+          {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
+        </span>
+      ) : null}
+      {/* Compact expiry chip (grid only): reads the SAME expiry the drawer states
+          in full, condensed to "88d" / "8d" / "Expired". One carrier per meaning. */}
+      {showExpiry && expiry ? (
+        <span className={styles.expiryChip} data-state={expiry.state} aria-hidden="true">
+          {expiry.short}
+        </span>
+      ) : null}
+      {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
     </span>
-    {/* On-chain pip: the ONE carrier of on-chain state. Glyph only when it relates
-        to the chain (minted / mintable); "none" is a recessive muted disc. */}
-    {showPip ? (
-      <span className={styles.pip} aria-hidden="true">
-        {stamp.onchain === "none" ? null : <LinkIcon size={compact ? 8 : 9} strokeWidth={2} />}
-      </span>
-    ) : null}
-    {showPoints ? <span className={styles.points}>+{stamp.points}</span> : null}
-  </span>
-);
+  );
+};
 
 /**
  * Interim loader, mirroring ScoreWindow's ScoreLoader (a simple indeterminate
@@ -215,11 +265,46 @@ const Pager: React.FC<{ page: number; pageCount: number; onPage: (p: number) => 
 );
 
 /**
+ * Category selector (segmented control): one segment per real Passport category.
+ * Each segment carries the category glyph + a verified/total count; the active
+ * segment is highlighted. This is the PRIMARY navigation - it switches the whole
+ * grid to that category (no blind whole-catalog paging). The full verbatim name
+ * rides on the active-category heading below + every segment's accessible label.
+ */
+const CategoryTabs: React.FC<{
+  groups: CategoryGroup[];
+  active: number;
+  onSelect: (index: number) => void;
+}> = ({ groups, active, onSelect }) => (
+  <div className={styles.tabs} role="tablist" aria-label="Stamp categories">
+    {groups.map((g, i) => (
+      <button
+        type="button"
+        key={g.category}
+        role="tab"
+        aria-selected={i === active}
+        className={`${styles.tab} ${i === active ? styles.tabOn : ""}`}
+        onClick={() => onSelect(i)}
+        title={`${g.category}. ${g.verified} of ${g.stamps.length} verified.`}
+        aria-label={`${g.category}. ${g.verified} of ${g.stamps.length} verified.`}
+      >
+        <span className={styles.tabIcon} aria-hidden="true">
+          {CATEGORY_ICONS[g.category] ?? <StarIcon size={18} strokeWidth={1.6} />}
+        </span>
+        <span className={styles.tabCount}>
+          {g.verified}/{g.stamps.length}
+        </span>
+      </button>
+    ))}
+  </div>
+);
+
+/**
  * StampsWindow - the medallion catalog, rendered INSIDE PassportShell like the
- * Score window. Stamps are glass plaques grouped by category, paginated and never
- * scrolled (§4 / §Windows). Presentational: props only, no data hooks, both-theme
- * legible, reduced-motion aware. Tapping a badge fires onSelectStamp; the detail
- * drawer is a later slice.
+ * Score window. Stamps are glass plaques navigated BY CATEGORY (a segmented
+ * control at the top), and within a category paginated and never scrolled
+ * (§4 / §Windows). Presentational: props only, no data hooks, both-theme legible,
+ * reduced-motion aware. Tapping a badge fires onSelectStamp.
  */
 export const StampsWindow: React.FC<StampsWindowProps> = ({
   stamps,
@@ -227,22 +312,46 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
   onVerify,
   verifyLabel,
   pageSize,
+  initialCategory,
   headline,
   emptyLabel,
   loading = false,
   size = "full",
 }) => {
-  const [page, setPage] = useState(0);
   const per = pageSize ?? DEFAULT_PAGE_SIZE[size];
   const compact = size !== "full";
 
-  const pages = useMemo(() => paginate(stamps, per), [stamps, per]);
+  const categories = useMemo(() => deriveCategories(stamps), [stamps]);
+  const initialActive = useMemo(() => {
+    const i = categories.findIndex((c) => c.category === initialCategory);
+    return i >= 0 ? i : 0;
+  }, [categories, initialCategory]);
+
+  // active = which category tab is selected (full only); page = the page WITHIN
+  // that category. Switching category resets the page to its first (bug fix: the
+  // old flat pager split a single category across pages and mislabeled counts).
+  const [active, setActive] = useState(initialActive);
+  const [page, setPage] = useState(0);
+  const activeIndex = Math.min(active, Math.max(0, categories.length - 1));
+  const selectCategory = (i: number) => {
+    setActive(i);
+    setPage(0);
+  };
+  // Keep the page valid if the active category or data shrinks under the cursor.
+  useEffect(() => {
+    setPage(0);
+  }, [activeIndex]);
+
+  const verifiedCount = useMemo(() => stamps.filter((s) => s.verified).length, [stamps]);
+
+  // full navigates a single category; mini flattens the whole list (no tabs) to
+  // keep the half-size card to one short paged row.
+  const activeGroup = categories[activeIndex];
+  const source = compact ? stamps : activeGroup ? activeGroup.stamps : [];
+  const pages = useMemo(() => paginate(source, per), [source, per]);
   const pageCount = pages.length;
   const current = Math.min(page, pageCount - 1);
   const pageStamps = pages[current] ?? [];
-  const groups = useMemo(() => groupByCategory(pageStamps), [pageStamps]);
-
-  const verifiedCount = useMemo(() => stamps.filter((s) => s.verified).length, [stamps]);
 
   const winClass = `${styles.window} ${size === "mini" ? styles.miniWin : ""} ${
     size === "pill" ? styles.pillWin : ""
@@ -323,23 +432,20 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
     );
   }
 
-  return (
-    <div className={winClass}>
-      <p className={styles.srOnly} aria-live="polite">
-        {stamps.length} stamps, {verifiedCount} verified. Page {current + 1} of {pageCount}.
-      </p>
-
-      <div className={styles.head}>
-        <span className={styles.title}>{headline ?? "Your stamps"}</span>
-        <span className={styles.count}>
-          {verifiedCount}/{stamps.length} verified
-        </span>
-      </div>
-
-      <div className={styles.pages}>
-        {compact ? (
-          // mini stays simpler: one flat grid, no category headers, so the
-          // half-size card keeps to a single medallion row per page.
+  // ---- mini: no category tabs. One flat, paged, half-size grid. ----
+  if (compact) {
+    return (
+      <div className={winClass}>
+        <p className={styles.srOnly} aria-live="polite">
+          {stamps.length} stamps, {verifiedCount} verified. Page {current + 1} of {pageCount}.
+        </p>
+        <div className={styles.head}>
+          <span className={styles.title}>{headline ?? "Your stamps"}</span>
+          <span className={styles.count}>
+            {verifiedCount}/{stamps.length} verified
+          </span>
+        </div>
+        <div className={styles.pages}>
           <div className={styles.grid}>
             {pageStamps.map((s) => (
               <button
@@ -349,40 +455,61 @@ export const StampsWindow: React.FC<StampsWindowProps> = ({
                 onClick={() => onSelectStamp?.(s.id)}
                 aria-label={stampLabel(s)}
               >
-                <Medallion stamp={s} compact />
+                <Medallion stamp={s} compact showExpiry />
                 <span className={styles.name}>{s.name}</span>
               </button>
             ))}
           </div>
-        ) : (
-          groups.map((group) => (
-            <div className={styles.group} key={group.category}>
-              {/* Category header: tonal text + space, no hard line (§ no-hard-lines). */}
-              <div className={styles.catHead}>{group.category}</div>
-              <div className={styles.grid}>
-                {group.stamps.map((s) => (
-                  <button
-                    type="button"
-                    key={s.id}
-                    className={styles.badge}
-                    onClick={() => onSelectStamp?.(s.id)}
-                    aria-label={stampLabel(s)}
-                  >
-                    <Medallion stamp={s} />
-                    <span className={styles.name}>{s.name}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          ))
-        )}
+        </div>
+        {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
+      </div>
+    );
+  }
+
+  // ---- full: category selector + a single category's grid, paged within it. ----
+  return (
+    <div className={winClass}>
+      <p className={styles.srOnly} aria-live="polite">
+        {activeGroup?.category}. {activeGroup?.verified} of {activeGroup?.stamps.length} verified. Page{" "}
+        {current + 1} of {pageCount}.
+      </p>
+
+      <CategoryTabs groups={categories} active={activeIndex} onSelect={selectCategory} />
+
+      {activeGroup ? (
+        <div className={styles.catBar}>
+          {/* Verbatim category name (single line; full name in title + tab a11y
+              labels), plus its verified/total count. */}
+          <span className={styles.catName} title={activeGroup.category}>
+            {activeGroup.category}
+          </span>
+          <span className={styles.count}>
+            {activeGroup.verified}/{activeGroup.stamps.length}
+          </span>
+        </div>
+      ) : null}
+
+      <div className={styles.pages}>
+        <div className={styles.grid}>
+          {pageStamps.map((s) => (
+            <button
+              type="button"
+              key={s.id}
+              className={styles.badge}
+              onClick={() => onSelectStamp?.(s.id)}
+              aria-label={stampLabel(s)}
+            >
+              <Medallion stamp={s} showExpiry />
+              <span className={styles.name}>{s.name}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
       {pageCount > 1 ? <Pager page={current} pageCount={pageCount} onPage={setPage} /> : null}
 
-      {/* Bottom-pinned verify entry, consistent with the shell's primary CTA. mini
-          stays simpler and drops it to keep the half-size card uncluttered. */}
-      {onVerify && !compact ? (
+      {/* Bottom-pinned verify entry, consistent with the shell's primary CTA. */}
+      {onVerify ? (
         <button type="button" className={styles.cta} onClick={onVerify}>
           <span className={styles.ctaIcon}>
             <PlusIcon size={15} strokeWidth={2} />

--- a/src/redesign/deriveTints.ts
+++ b/src/redesign/deriveTints.ts
@@ -1,0 +1,95 @@
+/**
+ * Palette derivation for the score drill-down (SOP §4).
+ *
+ * The drill-down arcs draw ONLY from the embed's accent - one hue family,
+ * stepped tints/shades. No rainbow, no invented colors, no legend. These
+ * helpers take the accent color and produce N legible mid-tone tints, ordered
+ * so the largest contribution gets the base hue and deeper ranks step within
+ * the same family.
+ *
+ * Lightness is deliberately clamped to a mid band so the arcs (and the white
+ * points that ride on them) stay legible in BOTH light and dark themes - the
+ * accent's own lightness varies by theme, but the derived arc lightness does
+ * not.
+ */
+
+export type RGB = [number, number, number];
+
+/** Parse an "r, g, b" CSS triplet (the shape our color tokens use). */
+export const parseRgbTriplet = (value: string): RGB | null => {
+  const m = value.trim().match(/(\d+(?:\.\d+)?)\D+(\d+(?:\.\d+)?)\D+(\d+(?:\.\d+)?)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+};
+
+export const rgbToHsl = ([r, g, b]: RGB): [number, number, number] => {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / d + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / d + 2;
+        break;
+      default:
+        h = (rn - gn) / d + 4;
+        break;
+    }
+    h *= 60;
+  }
+  return [h, s * 100, l * 100];
+};
+
+export const hslToRgb = (h: number, s: number, l: number): RGB => {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = ln - c / 2;
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+};
+
+const DEFAULT_ACCENT: RGB = [16, 185, 129]; // Human Passport emerald (#10B981)
+
+/**
+ * Derive `count` arc colors from `accent`, ranked (index 0 = largest slice).
+ * ONE hue family (SOP §4, "no rainbow"): the accent's hue and saturation are
+ * held fixed and only LIGHTNESS steps per rank, so every arc reads as the same
+ * emerald - no hue-rotation drift toward teal/green. Lightness stays in a mid
+ * band so the white points that ride on each arc stay legible in both themes.
+ */
+export const deriveTints = (accent: RGB | null, count: number): string[] => {
+  const base = accent ?? DEFAULT_ACCENT;
+  const [h, s] = rgbToHsl(base);
+  const hue = h; // fixed - never rotated
+  const sat = Math.min(Math.max(s, 55), 80);
+  const out: string[] = [];
+  for (let i = 0; i < count; i++) {
+    // Largest slice (i=0) is the deepest tone; deeper ranks step lighter within
+    // the same emerald family. Clamped to a mid band (≤72) for point legibility.
+    const light = Math.min(44 + i * 6, 72);
+    const [r, g, b] = hslToRgb(hue, sat, light);
+    out.push(`rgb(${r}, ${g}, ${b})`);
+  }
+  return out;
+};

--- a/src/redesign/expiry.ts
+++ b/src/redesign/expiry.ts
@@ -1,0 +1,50 @@
+/**
+ * Stamp expiry helpers.
+ *
+ * Every Human Passport stamp expires as a whole: the score endpoint returns a
+ * per-stamp `expiration_date`, and the default credential lifetime is 90 days.
+ * These helpers turn that ISO date into plain, dash-free copy for the drawer
+ * header ("Valid for N days" / "Expires {date}" / "Expired") and a compact form
+ * for the grid medallion chip ("88d" / "8d" / "Expired").
+ */
+
+export type ExpiryState = "valid" | "soon" | "expired";
+
+export type ExpiryInfo = {
+  state: ExpiryState;
+  /** Whole days remaining (0 once expired). */
+  days: number;
+  /** Full phrasing for the drawer header. */
+  long: string;
+  /** Compact phrasing for the grid medallion chip. */
+  short: string;
+};
+
+/** Below this many days remaining, a stamp reads as "expiring soon" (amber). */
+const SOON_DAYS = 14;
+const DAY_MS = 86_400_000;
+
+/**
+ * Format a stamp's expiry. Returns null when no date is supplied. `now` is
+ * injectable so tests / stories can pin a reference point.
+ */
+export const formatExpiry = (iso?: string, now: Date = new Date()): ExpiryInfo | null => {
+  if (!iso) return null;
+  const exp = new Date(iso);
+  if (Number.isNaN(exp.getTime())) return null;
+
+  const days = Math.ceil((exp.getTime() - now.getTime()) / DAY_MS);
+  if (days <= 0) {
+    return { state: "expired", days: 0, long: "Expired", short: "Expired" };
+  }
+
+  const date = exp.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  if (days <= SOON_DAYS) {
+    return { state: "soon", days, long: `Expires ${date}`, short: `${days}d` };
+  }
+  return { state: "valid", days, long: `Valid for ${days} days`, short: `${days}d` };
+};
+
+/** ISO date string N days from `from` (default now). Keeps mock expiry copy stable. */
+export const daysFromNow = (n: number, from: Date = new Date()): string =>
+  new Date(from.getTime() + n * DAY_MS).toISOString();

--- a/src/redesign/glassTip.module.css
+++ b/src/redesign/glassTip.module.css
@@ -1,0 +1,50 @@
+/*
+ * Glass tooltip skin for the redesign (§ materials / tooltips-become-glass).
+ *
+ * Passed as `className` to the shared <Tooltip>, so it layers onto the tooltip's
+ * own `.tooltip` element WITHOUT editing the shipped Tooltip module (which the
+ * live widget still uses). Translucent + blurred material, soft, no hard border.
+ *
+ * Legibility first (§8, >=4.5:1): the tooltip floats over unknown host content,
+ * so a single translucent layer is not enough on its own. We stack a near-opaque
+ * surface SCRIM (0.9 of --surface) under the blur, so the text always sits on a
+ * strong, on-theme backdrop while the edges still read as glass. `--on-surface`
+ * over 0.9 `--surface` clears AA in both themes.
+ */
+.tip {
+  /* override the shipped solid surface + 1px border with glass */
+  background:
+    linear-gradient(rgba(var(--surface), 0.9), rgba(var(--surface), 0.9)),
+    rgba(var(--surface), 0.6) !important;
+  border: 0 !important;
+  color: rgb(var(--on-surface)) !important;
+  -webkit-backdrop-filter: blur(14px) saturate(1.3);
+  backdrop-filter: blur(14px) saturate(1.3);
+  box-shadow:
+    0 8px 30px rgba(0, 0, 0, 0.22),
+    inset 0 0 0 1px rgba(var(--on-surface), 0.06) !important;
+  font-size: var(--font-size-sm-c6dbf459) !important;
+  font-weight: var(--weight-medium-c6dbf459);
+  line-height: var(--line-normal-c6dbf459) !important;
+  max-width: 240px !important;
+}
+
+/* The arrow is the tooltip's LAST child div (after the .content div). Reskin it
+ * to match the glass and drop its hard border, without reaching into the other
+ * module's hashed class name. */
+.tip > div:last-child {
+  background: rgba(var(--surface), 0.9) !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+/* Emphasis + the "tap to see how it's computed" tail read a touch quieter. */
+.tip b,
+.tip strong {
+  color: rgb(var(--on-surface));
+  font-weight: var(--weight-semibold-c6dbf459);
+}
+.tip em {
+  font-style: normal;
+  color: rgba(var(--on-surface), 0.72);
+}

--- a/src/redesign/hooks.ts
+++ b/src/redesign/hooks.ts
@@ -1,0 +1,63 @@
+import { RefObject, useEffect, useState } from "react";
+import { parseRgbTriplet, RGB } from "./deriveTints";
+
+/** True when the user asked for reduced motion. SSR-safe. */
+export const useReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener?.("change", update);
+    return () => mq.removeEventListener?.("change", update);
+  }, []);
+  return reduced;
+};
+
+/**
+ * Resolve the widget's `--accent` token (an "r, g, b" triplet) from a mounted
+ * element, so derived palettes stay in lock-step with whatever theme the host
+ * passed. Falls back to an explicit override, then to null (deriveTints seeds a
+ * default).
+ */
+export const useAccentRgb = (ref: RefObject<HTMLElement>, override?: string): RGB | null => {
+  const [rgb, setRgb] = useState<RGB | null>(() => (override ? parseRgbTriplet(override) : null));
+  useEffect(() => {
+    if (override) {
+      setRgb(parseRgbTriplet(override));
+      return;
+    }
+    if (typeof window === "undefined" || !ref.current) return;
+    const resolved = getComputedStyle(ref.current).getPropertyValue("--accent");
+    const parsed = parseRgbTriplet(resolved);
+    if (parsed) setRgb(parsed);
+  }, [ref, override]);
+  return rgb;
+};
+
+/**
+ * Animated count-up from 0 to `target`. Returns the current display value.
+ * Collapses to the final value instantly under reduced-motion.
+ */
+export const useCountUp = (target: number, durationMs: number, reduced: boolean): number => {
+  const [value, setValue] = useState(reduced ? target : 0);
+  useEffect(() => {
+    if (reduced || typeof window === "undefined" || !window.requestAnimationFrame) {
+      setValue(target);
+      return;
+    }
+    let raf = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / durationMs, 1);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(target * eased);
+      if (t < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [target, durationMs, reduced]);
+  return value;
+};

--- a/src/redesign/humanizeError.ts
+++ b/src/redesign/humanizeError.ts
@@ -1,0 +1,87 @@
+/*
+ * humanizeError - map a failure to friendly, human copy (§ score states / copy).
+ *
+ * The score window NEVER shows a raw `error.message`. Every failure is mapped to
+ * a short title, a plain one-sentence explanation, and whether a retry is worth
+ * offering. Callers pass either a known kind or an unknown thrown value (an axios
+ * error, a DOMException, a string); we sniff the kind from it. Copy is deliberately
+ * simple and dash free.
+ */
+
+export type ErrorKind = "network" | "rate-limit" | "timeout" | "unknown";
+
+export type HumanError = {
+  kind: ErrorKind;
+  /** Short headline for the error state. */
+  title: string;
+  /** One plain sentence the user can act on. */
+  message: string;
+  /** Whether a retry affordance should be shown. */
+  retryable: boolean;
+};
+
+const COPY: Record<ErrorKind, Omit<HumanError, "kind">> = {
+  network: {
+    title: "No connection",
+    message: "We could not reach the network. Check your connection and try again.",
+    retryable: true,
+  },
+  "rate-limit": {
+    title: "Too many requests",
+    message: "You have made a lot of requests. Wait a moment, then try again.",
+    retryable: true,
+  },
+  timeout: {
+    title: "This is taking too long",
+    message: "The request timed out before we heard back. Try again.",
+    retryable: true,
+  },
+  unknown: {
+    title: "Something went wrong",
+    message: "We could not load your score just now. Try again.",
+    retryable: true,
+  },
+};
+
+/** Best-effort sniff of an error kind from an unknown thrown value. */
+export const classifyError = (input: unknown): ErrorKind => {
+  if (input == null) return "unknown";
+
+  // A numeric-ish status (429) anywhere on the value.
+  const status =
+    typeof input === "object" && input !== null
+      ? // axios shape: err.response.status, or err.status
+        (input as { response?: { status?: number }; status?: number }).response?.status ??
+        (input as { status?: number }).status
+      : undefined;
+  if (status === 429) return "rate-limit";
+  if (status === 408 || status === 504) return "timeout";
+
+  const text = (
+    typeof input === "string"
+      ? input
+      : input instanceof Error
+        ? `${input.name} ${input.message}`
+        : (() => {
+            try {
+              return JSON.stringify(input);
+            } catch {
+              return String(input);
+            }
+          })()
+  ).toLowerCase();
+
+  if (/429|rate.?limit|too many/.test(text)) return "rate-limit";
+  if (/time?out|timed out|deadline|abort/.test(text)) return "timeout";
+  if (/network|failed to fetch|offline|dns|econn|enotfound|connection/.test(text)) return "network";
+  return "unknown";
+};
+
+/** Map a kind, or an unknown thrown value, to friendly error copy. */
+export const humanizeError = (input: ErrorKind | unknown): HumanError => {
+  const kind: ErrorKind =
+    input === "network" || input === "rate-limit" || input === "timeout" || input === "unknown"
+      ? input
+      : classifyError(input);
+  return { kind, ...COPY[kind] };
+};

--- a/src/redesign/icons.tsx
+++ b/src/redesign/icons.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+
+/**
+ * Small stroke-icon set for the redesign shell + score windows.
+ *
+ * Every icon draws with `stroke: currentColor` (via the shared `gl` styling on
+ * the consuming CSS module), so an icon inherits the token-driven color of its
+ * context and is legible in BOTH themes. No hardcoded fills/strokes here.
+ */
+
+type IconProps = {
+  className?: string;
+  size?: number;
+  strokeWidth?: number;
+  title?: string;
+};
+
+const Svg: React.FC<IconProps & { children: React.ReactNode; viewBox?: string }> = ({
+  className,
+  size = 16,
+  strokeWidth = 1.6,
+  title,
+  viewBox = "0 0 24 24",
+  children,
+}) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox={viewBox}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    role={title ? "img" : "presentation"}
+    aria-hidden={title ? undefined : true}
+    aria-label={title}
+    focusable="false"
+  >
+    {title ? <title>{title}</title> : null}
+    {children}
+  </svg>
+);
+
+/** Placeholder integrator app-icon (a cube). */
+export const CubeIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 2.5 21 7v10l-9 4.5L3 17V7z" />
+    <path d="M3 7l9 4.5L21 7" />
+    <path d="M12 11.5V21.5" />
+  </Svg>
+);
+
+export const CaretDownIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M6 9l6 6 6-6" />
+  </Svg>
+);
+
+export const CheckIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M20 6 9 17l-5-5" />
+  </Svg>
+);
+
+export const ShieldIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 2.5 20 6v6c0 5-3.5 8-8 9.5C7.5 20 4 17 4 12V6z" />
+  </Svg>
+);
+
+export const StarIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 3.5l2.6 5.3 5.9.85-4.25 4.15 1 5.85L12 16.9l-5.25 2.75 1-5.85L3.5 9.65l5.9-.85z" />
+  </Svg>
+);
+
+export const InfoIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9.5" />
+    <path d="M12 16.5v-5M12 8h.01" />
+  </Svg>
+);
+
+export const RetryIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M20 11a8 8 0 1 0-1.5 5" />
+    <path d="M20 4.5V11h-6.5" />
+  </Svg>
+);
+
+export const ArrowLeftIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M19 12H5M11 18l-6-6 6-6" />
+  </Svg>
+);
+
+export const SparkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 3v4M12 17v4M4.9 7.4l2.6 2.6M16.5 14l2.6 2.6M3 12h4M17 12h4M4.9 16.6l2.6-2.6M16.5 10l2.6-2.6" />
+  </Svg>
+);
+
+/** Wallet (used for the link-wallet CTA + linked-wallet rows). */
+export const WalletIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M3 7.5A2.5 2.5 0 0 1 5.5 5H18a2 2 0 0 1 2 2v1H6a1.5 1.5 0 0 0 0 3H20a1 1 0 0 1 1 1v3a2 2 0 0 1-2 2H5.5A2.5 2.5 0 0 1 3 15.5z" />
+    <path d="M16.5 12.5h.01" />
+  </Svg>
+);
+
+/** Plus / add affordance (link additional wallet, add verifications). */
+export const PlusIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M12 5v14M5 12h14" />
+  </Svg>
+);
+
+/** Copy (two stacked sheets) - copy an address / wallet to the clipboard. */
+export const CopyIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <rect x="9" y="9" width="12" height="12" rx="2.2" />
+    <path d="M6 15H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1" />
+  </Svg>
+);
+
+/** Chain link (link an identity). Two interlocking links, not a wallet. */
+export const LinkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M9.5 14.5 14.5 9.5" />
+    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
+    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
+  </Svg>
+);
+
+/** Unlink (break the chain) - remove a linked wallet. */
+export const UnlinkIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
+    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
+    <path d="M3 3l18 18" />
+  </Svg>
+);
+
+/** Small clock (cooldown / pending wallet status). */
+export const ClockIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7.5V12l3 2" />
+  </Svg>
+);
+
+/** Sign out. */
+export const LogoutIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M15 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3" />
+    <path d="M10 17l-5-5 5-5M4 12h11" />
+  </Svg>
+);
+
+/** Switch accounts (two-way). */
+export const SwitchIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M4 8h13l-3-3M20 16H7l3 3" />
+  </Svg>
+);
+
+/**
+ * WaaP mark - the "Wallet as a Passport" account behind the passport. A small
+ * booklet/passport glyph with a quatrefoil-ish humanity dot, drawn on brand and
+ * legible in both themes (currentColor stroke). Not a crop of the full lockup.
+ */
+export const WaaPIcon: React.FC<IconProps> = (p) => (
+  <Svg {...p}>
+    <path d="M5 4.5A1.5 1.5 0 0 1 6.5 3H17a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6.5A1.5 1.5 0 0 1 5 19.5z" />
+    <path d="M5 17h12" />
+    <circle cx="12" cy="9" r="2.4" />
+  </Svg>
+);

--- a/src/redesign/icons.tsx
+++ b/src/redesign/icons.tsx
@@ -125,21 +125,23 @@ export const CopyIcon: React.FC<IconProps> = (p) => (
   </Svg>
 );
 
-/** Chain link (link an identity). Two interlocking links, not a wallet. */
+/**
+ * Chain link (on-chain / link an identity). Two interlocking capsules that read
+ * cleanly at both the small on-chain pip size and the drawer button size. Drawn
+ * as a single cohesive glyph (the old version rendered as three broken strokes).
+ */
 export const LinkIcon: React.FC<IconProps> = (p) => (
   <Svg {...p}>
-    <path d="M9.5 14.5 14.5 9.5" />
-    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
-    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
   </Svg>
 );
 
-/** Unlink (break the chain) - remove a linked wallet. */
+/** Unlink (break the chain) - remove a linked wallet. One capsule half + a slash. */
 export const UnlinkIcon: React.FC<IconProps> = (p) => (
   <Svg {...p}>
-    <path d="M8 12.5 6.7 13.8a3 3 0 0 1-4.2-4.2L5 7" />
-    <path d="M16 11.5 17.3 10.2a3 3 0 0 0-4.2-4.2L11 8" />
-    <path d="M3 3l18 18" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    <path d="M4 4l16 16" />
   </Svg>
 );
 

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Redesign slice 1 - Shell + Score window (SOP §4 / spine.md).
+ *
+ * Presentational, props-only components (no data hooks), rendered alongside the
+ * existing shipped widget. The shipped `PassportScoreWidget` is untouched.
+ */
+export { PassportShell } from "./PassportShell";
+export type {
+  PassportShellProps,
+  ShellAccount,
+  ShellAccountOption,
+  LinkedWallet,
+  LinkedWalletStatus,
+  ShellSize,
+} from "./PassportShell";
+
+export { ScoreWindow } from "./ScoreWindow";
+export type { ScoreWindowProps, ScoreWindowState, ShellCta } from "./ScoreWindow";
+
+export { ScoreDrilldown } from "./ScoreDrilldown";
+export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
+
+export { ScoreHome } from "./ScoreHome";
+export type { ScoreHomeProps } from "./ScoreHome";
+
+export { SecuredByFooter } from "./SecuredByFooter";
+
+export { humanizeError, classifyError } from "./humanizeError";
+export type { ErrorKind, HumanError } from "./humanizeError";

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -23,6 +23,9 @@ export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
 export { ScoreHome } from "./ScoreHome";
 export type { ScoreHomeProps } from "./ScoreHome";
 
+export { StampsWindow } from "./StampsWindow";
+export type { StampsWindowProps, Stamp, StampOnchain } from "./StampsWindow";
+
 export { SecuredByFooter } from "./SecuredByFooter";
 
 export { humanizeError, classifyError } from "./humanizeError";

--- a/src/redesign/index.ts
+++ b/src/redesign/index.ts
@@ -23,8 +23,16 @@ export type { ScoreDrilldownProps, StampContribution } from "./ScoreDrilldown";
 export { ScoreHome } from "./ScoreHome";
 export type { ScoreHomeProps } from "./ScoreHome";
 
-export { StampsWindow } from "./StampsWindow";
-export type { StampsWindowProps, Stamp, StampOnchain } from "./StampsWindow";
+export { StampsWindow, Medallion } from "./StampsWindow";
+export type { StampsWindowProps, Stamp, StampOnchain, MedallionProps } from "./StampsWindow";
+
+export { StampDetailDrawer } from "./StampDetailDrawer";
+export type {
+  StampDetailDrawerProps,
+  StampDetail,
+  StampComponent,
+  StampAction,
+} from "./StampDetailDrawer";
 
 export { SecuredByFooter } from "./SecuredByFooter";
 

--- a/src/redesign/stampIcons.tsx
+++ b/src/redesign/stampIcons.tsx
@@ -1,0 +1,397 @@
+import React from "react";
+
+/**
+ * Real Human Passport stamp icons, as inline SVG React nodes.
+ *
+ * In production the embed renders each platform's REAL icon: the
+ * `/embed/stamps/metadata` endpoint returns `platform.icon` as an inline SVG
+ * string, which the widget renders through `SanitizedHTMLComponent`. These
+ * components carry the SAME geometry as those shipped assets (taken from
+ * passportxyz/passport `app/public/assets/*.svg`), redrawn as currentColor so
+ * a medallion glyph adapts to the token color of its context and stays legible
+ * in BOTH themes (the Storybook mock has no network + no asset pipeline).
+ *
+ * Every catalog platform below has an entry in STAMP_ICONS, keyed by the
+ * platform id used across the mock catalog + drawer detail.
+ */
+
+type IconProps = { size?: number };
+
+const box = (size: number, viewBox: string, children: React.ReactNode, mode: "fill" | "stroke") => (
+  <svg
+    width={size}
+    height={size}
+    viewBox={viewBox}
+    fill={mode === "fill" ? "currentColor" : "none"}
+    stroke={mode === "stroke" ? "currentColor" : "none"}
+    strokeWidth={mode === "stroke" ? 2 : undefined}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {children}
+  </svg>
+);
+
+/* ---- Physical Verification ---- */
+
+// Government ID (HumanIdKyc) - real idCard.svg
+export const GovIdIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M16 10H18M16 14H18M6.17 15C6.37614 14.414 6.7591 13.9065 7.26602 13.5474C7.77294 13.1884 8.37881 12.9955 9 12.9955C9.62119 12.9955 10.2271 13.1884 10.734 13.5474C11.2409 13.9065 11.6239 14.414 11.83 15M11 11C11 12.1046 10.1046 13 9 13C7.89543 13 7 12.1046 7 11C7 9.89543 7.89543 9 9 9C10.1046 9 11 9.89543 11 11ZM4 5H20C21.1046 5 22 5.89543 22 7V17C22 18.1046 21.1046 19 20 19H4C2.89543 19 2 18.1046 2 17V7C2 5.89543 2.89543 5 4 5Z" />,
+    "stroke"
+  );
+
+// Phone Verification (HumanIdPhone) - real smartphone.svg
+export const PhoneIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 18H12.01M7 2H17C18.1046 2 19 2.89543 19 4V20C19 21.1046 18.1046 22 17 22H7C5.89543 22 5 21.1046 5 20V4C5 2.89543 5.89543 2 7 2Z" />,
+    "stroke"
+  );
+
+// Biometrics - real biometrics.svg (framed face)
+export const BiometricsIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M3 7V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H7M17 3H19C19.5304 3 20.0391 3.21071 20.4142 3.58579C20.7893 3.96086 21 4.46957 21 5V7M21 17V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21H17M7 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V17M8 14C8 14 9.5 16 12 16C14.5 16 16 14 16 14M9 9H9.01M15 9H15.01" />,
+    "stroke"
+  );
+
+// Proof of Clean Hands - real cleanHands.svg (raised hand + sparkles)
+export const CleanHandsIcon: React.FC<IconProps> = ({ size = 22 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M17.8168 12.65V8.4C17.8168 7.94913 17.6491 7.51673 17.3506 7.19792C17.0522 6.87911 16.6473 6.7 16.2252 6.7C15.8031 6.7 15.3983 6.87911 15.0998 7.19792C14.8013 7.51673 14.6336 7.94913 14.6336 8.4M14.6336 11.8V6.7C14.6336 6.24913 14.4659 5.81673 14.1674 5.49792C13.869 5.17911 13.4641 5 13.042 5C12.6199 5 12.2151 5.17911 11.9166 5.49792C11.6181 5.81673 11.4504 6.24913 11.4504 6.7V8.4M11.4504 8.4V12.225M11.4504 8.4C11.4504 7.94913 11.2827 7.51673 10.9842 7.19792C10.6858 6.87911 10.2809 6.7 9.85881 6.7C9.43669 6.7 9.03186 6.87911 8.73338 7.19792C8.4349 7.51673 8.26721 7.94913 8.26721 8.4V15.2M17.8168 10.1C17.8168 9.64913 17.9845 9.21673 18.283 8.89792C18.5815 8.57911 18.9863 8.4 19.4084 8.4C19.8305 8.4 20.2353 8.57911 20.5338 8.89792C20.8323 9.21673 21 9.64913 21 10.1V15.2C21 17.0035 20.3293 18.7331 19.1353 20.0083C17.9414 21.2836 16.3221 22 14.6336 22H13.042C10.8138 22 9.46091 21.269 8.27517 20.011L5.41029 16.951C5.13649 16.6271 4.98978 16.2031 5.00055 15.7669C5.01133 15.3307 5.17875 14.9155 5.46816 14.6075C5.75757 14.2995 6.14681 14.1221 6.55527 14.1122C6.96373 14.1022 7.36013 14.2604 7.6624 14.554L9.06301 16.05" />
+    <path
+      fill="currentColor"
+      stroke="none"
+      d="M2.49045 11.06C2.87449 11.1163 3.35307 11.06 3.35307 11.4371C3.35307 11.5864 3.41532 11.7296 3.52612 11.8351C3.63692 11.9407 3.7872 12 3.9439 12C4.1006 12 4.25088 11.9407 4.36168 11.8351C4.47249 11.7296 4.53474 11.5864 4.53474 11.4371C4.54064 11.1413 4.97195 11.1163 5.40917 11.0544C5.56587 11.0544 5.71615 10.9951 5.82695 10.8896C5.93775 10.784 6 10.6408 6 10.4916C6 10.3423 5.93775 10.1991 5.82695 10.0936C5.71615 9.98801 5.56587 9.92871 5.40917 9.92871C4.97195 9.87242 4.53474 9.87835 4.54064 9.56285C4.54064 9.41357 4.47839 9.27041 4.36759 9.16486C4.25679 9.0593 4.10651 9 3.94981 9C3.79311 9 3.64283 9.0593 3.53203 9.16486C3.42123 9.27041 3.35898 9.41357 3.35898 9.56285C3.35898 9.92871 2.91585 9.88368 2.51409 9.93433C2.37105 9.95219 2.23981 10.0193 2.14512 10.123C2.05044 10.2267 1.99884 10.3598 2.00006 10.4972C1.99802 10.6313 2.04629 10.7617 2.1362 10.8648C2.2261 10.968 2.35173 11.0373 2.49045 11.06Z"
+    />
+    <path
+      fill="currentColor"
+      stroke="none"
+      d="M6.03858 7.36307C6.03858 5.65834 9.36569 5.08385 9.4016 5.08385C9.5603 5.08385 9.71251 5.01806 9.82473 4.90096C9.93695 4.78385 10 4.62502 10 4.45941C10 4.2938 9.93695 4.13497 9.82473 4.01786C9.71251 3.90076 9.5603 3.83497 9.4016 3.83497C9.34774 3.84121 6.03858 3.3479 6.03858 1.62444C6.03858 1.45883 5.97553 1.3 5.86331 1.1829C5.75109 1.06579 5.59889 1 5.44018 1C5.28147 1 5.12927 1.06579 5.01705 1.1829C4.90482 1.3 4.84178 1.45883 4.84178 1.62444C4.84178 3.3479 1.55057 3.85995 1.52065 3.86619C1.37578 3.88601 1.24286 3.96045 1.14696 4.07547C1.05106 4.1905 0.998799 4.33817 1.00004 4.49063C0.998407 4.64123 1.04899 4.78736 1.14246 4.90211C1.23593 5.01686 1.36599 5.09249 1.50868 5.11508C1.54458 5.11508 4.84178 5.67083 4.84178 7.37556C4.84178 7.54117 4.90482 7.7 5.01705 7.8171C5.12927 7.93421 5.28147 8 5.44018 8C5.59889 8 5.75109 7.93421 5.86331 7.8171C5.97553 7.7 6.03858 7.54117 6.03858 7.37556V7.36307Z"
+    />
+  </svg>
+);
+
+// Binance - real binanceStamp.svg diamond (script tags dropped, brand color -> currentColor)
+export const BinanceIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 45 45",
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M13.7642 18.9085L22.504 10.1722L31.2474 18.9156L36.33 13.8295L22.504 0L8.6781 13.8259L13.7642 18.9085ZM0 22.5008L5.08424 17.4166L10.1685 22.5008L5.08424 27.5851L0 22.5008ZM22.504 34.8313L13.7642 26.0914L8.67096 31.1704L8.67807 31.1775L22.504 44.9999L36.3299 31.1704L36.3335 31.1668L31.2474 26.0879L22.504 34.8313ZM34.83 22.5022L39.9142 17.418L44.9984 22.5022L39.9142 27.5864L34.83 22.5022ZM22.504 17.3375L27.6612 22.4983H27.6647L27.6612 22.5018L22.504 27.6625L17.3468 22.5089L17.3397 22.4983L17.3468 22.4911L18.2496 21.5884L18.6903 21.1512L22.504 17.3375Z"
+    />,
+    "fill"
+  );
+
+// Civic - real civic person-in-C mark (brand orange -> currentColor)
+export const CivicIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 218 219",
+    <>
+      <path d="m131.246 92.7977c0-12.1689-9.864-22.0331-22.033-22.0331-12.1678 0-22.0326 9.8641-22.0326 22.0331 0 8.5143 4.838 15.8873 11.9082 19.5553l-8.1658 35.311h36.5812l-8.165-35.311c7.069-3.668 11.907-11.041 11.907-19.5553z" />
+      <path d="m195.392 136.983c-4.279 33.225-32.727 58.986-67.098 58.986h-38.1611c-37.3161 0-67.6751-30.359-67.6751-67.675v-38.1603c0-37.3162 30.359-67.6752 67.6751-67.6752h38.1611c34.371 0 62.818 25.7624 67.098 58.9872h22.608c-4.386-45.6383-42.938-81.4457-89.706-81.4457h-38.1611c-49.7472 0-90.1341 40.3869-90.1341 90.134v38.1603c0 49.748 40.3869 90.134 90.1341 90.134h38.1611c46.768 0 85.32-35.807 89.706-81.446z" />
+    </>,
+    "fill"
+  );
+
+// Coinbase - real coinbase circle-with-bar (brand blue -> currentColor)
+export const CoinbaseIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M11.9805 1.5C17.7908 1.5 22.5 6.20182 22.5 12C22.5 17.7981 17.7908 22.5 11.9805 22.5C6.65457 22.4998 2.25386 18.5489 1.55762 13.4248H16.0645V10.5752H1.55762C2.25383 5.45115 6.65454 1.50018 11.9805 1.5Z" />,
+    "fill"
+  );
+
+/* ---- Blockchain Networks and Activities ---- */
+
+// ENS - simplified tilted-prism ENS mark, currentColor (real asset uses gradients)
+export const EnsIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 2 6 11.5c-1 1.6-1 3.6 0 5.2L12 22l6-5.3c1-1.6 1-3.6 0-5.2L12 2Zm0 3.4 3.7 6c.5.8.5 1.9 0 2.7L12 18.6l-3.7-4.5c-.5-.8-.5-1.9 0-2.7L12 5.4Z" />,
+    "fill"
+  );
+
+// Ethereum - real ethStampIcon.svg diamond geometry, currentColor
+export const EthIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 48 48",
+    <>
+      <path d="M11 24L25 2 39 24 25 32z" opacity={0.6} />
+      <path d="M11 27L25 35 39 27 25 46z" opacity={0.6} />
+      <path d="M25 2L39 24 25 32zM25 35L39 27 25 46zM11 24L25 18 39 24 25 32z" />
+      <path d="M25 18L39 24 25 32z" />
+    </>,
+    "fill"
+  );
+
+// Gitcoin Grants - flower / hex mark, currentColor
+export const GitcoinIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <>
+      <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 3a7 7 0 1 1 0 14 7 7 0 0 1 0-14Z" />
+      <circle cx="12" cy="12" r="3" />
+    </>,
+    "fill"
+  );
+
+// Identity Staking (GtcStaking) - real gtcStaking knot geometry, currentColor
+export const GtcStakingIcon: React.FC<IconProps> = ({ size = 22 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 40 40"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      opacity={0.85}
+      d="M17.8202 13.8133C21.2351 10.3984 26.7718 10.3984 30.1867 13.8133C33.6017 17.2283 33.6016 22.7649 30.1867 26.1798L22.5498 33.8167C19.1349 37.2317 13.5982 37.2317 10.1833 33.8167C6.76841 30.4018 6.76841 24.8651 10.1833 21.4502L17.8202 13.8133Z"
+    />
+    <path d="M30.1867 13.8201C33.6016 17.2351 33.6016 22.7717 30.1867 26.1867C26.7717 29.6016 21.2351 29.6016 17.8202 26.1867L14.0017 22.3682L10.1833 18.5498C6.76835 15.1348 6.76834 9.59817 10.1833 6.18325C13.5982 2.76833 19.1349 2.76833 22.5498 6.18325L26.3682 10.0017L30.1867 13.8201Z" />
+  </svg>
+);
+
+// NFT - framed-image mark, currentColor (real asset is a raster PNG)
+export const NftIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <>
+      <rect x="3" y="3" width="18" height="18" rx="3" />
+      <circle cx="9" cy="9" r="1.6" />
+      <path d="M4 16l4.5-4.5L14 17l3-3 3 3" />
+    </>,
+    "stroke"
+  );
+
+// Guild.xyz - shield / hex mark, currentColor
+export const GuildIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 2.5 20 6v6c0 5-3.5 8-8 9.5C7.5 20 4 17 4 12V6l8-3.5Z" />,
+    "stroke"
+  );
+
+// Lens - leaf / lens mark, currentColor
+export const LensIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 3c-4 4-4 10 0 14 4-4 4-10 0-14Zm0 0c4 4 4 10 0 14M5 12c4-1.5 10-1.5 14 0" />,
+    "stroke"
+  );
+
+// Snapshot - real snapshot lightning bolt (brand amber -> currentColor)
+export const SnapshotIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 105 126",
+    <path d="M104.781694,54.7785 C104.270697,53.41 102.961707,52.5 101.498717,52.5 L59.2365129,52.5 L83.6138421,5.103 C84.3803368,3.612 83.9848395,1.7885 82.6653488,0.7525 C82.0283532,0.2485 81.2618586,0 80.498864,0 C79.6833697,0 78.8678754,0.287 78.21338,0.8505 L52.4990602,23.058 L1.21391953,67.3505 C0.107927276,68.306 -0.291069928,69.8495 0.219926491,71.218 C0.730922911,72.5865 2.03641376,73.5 3.49940351,73.5 L45.7616074,73.5 L21.3842782,120.897 C20.6177836,122.388 21.0132808,124.2115 22.3327715,125.2475 C22.9697671,125.7515 23.7362617,126 24.4992564,126 C25.3147506,126 26.1302449,125.713 26.7847403,125.1495 L52.4990602,102.942 L103.784201,58.6495 C104.893693,57.694 105.28919,56.1505 104.781694,54.7785 Z" />,
+    "fill"
+  );
+
+// Safe (GnosisSafe) - vault / lock mark, currentColor
+export const SafeIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <>
+      <rect x="4" y="4" width="16" height="16" rx="3" />
+      <circle cx="12" cy="12" r="3.5" />
+      <path d="M12 8.5V6M12 18v-2.5M15.5 12H18M6 12h2.5" />
+    </>,
+    "stroke"
+  );
+
+// BrightID - real brightid connected-nodes mark (brand -> currentColor)
+export const BrightIdIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 48 48",
+    <>
+      <path d="M17.8154 18.0378V24.5451C17.8154 28.1394 20.7222 31.053 24.3078 31.053C27.8935 31.053 30.8 28.1394 30.8 24.5451C30.8 20.951 27.8935 18.0374 24.3078 18.0374C24.2998 18.0374 24.292 18.038 24.284 18.038V18.0378H17.8154Z" />
+      <path d="M25.3323 4H22.7155H17.8154V11.5295H24.2839V11.5301C24.2919 11.5301 24.2997 11.5295 24.3078 11.5295C31.4789 11.5295 37.2925 17.3565 37.2925 24.5452C37.2925 31.7336 31.4789 37.5606 24.3078 37.5606C17.1364 37.5606 11.3228 31.7336 11.3228 24.5452V18.0376H4V23.993H4.04782C4.05664 35.0442 12.9969 44 24.0239 44C35.0565 44 44.0006 35.0352 44.0006 23.9763C44.0006 13.3584 35.7545 4.6762 25.3323 4Z" />
+      <path d="M11.3022 4H4.0459V11.5847H11.3022V4Z" />
+    </>,
+    "fill"
+  );
+
+// Idena - prism / diamond mark, currentColor
+export const IdenaIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 2 3 12l9 10 9-10L12 2Zm0 4.5L17 12l-5 5.5L7 12l5-5.5Z" />,
+    "fill"
+  );
+
+// zkSync - hex mark, currentColor
+export const ZkSyncIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M12 2 3 7v10l9 5 9-5V7l-9-5Zm0 2.3 7 3.9v7.6l-7 3.9-7-3.9V8.2l7-3.9Z" />,
+    "stroke"
+  );
+
+/* ---- Web2 Platforms & Services ---- */
+
+// Discord - real discord mark (currentColor)
+export const DiscordIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 126.644 96",
+    <path d="M81.15,0c-1.2376,2.1973-2.3489,4.4704-3.3591,6.794-9.5975-1.4396-19.3718-1.4396-28.9945,0-.985-2.3236-2.1216-4.5967-3.3591-6.794-9.0166,1.5407-17.8059,4.2431-26.1405,8.0568C2.779,32.5304-1.6914,56.3725.5312,79.8863c9.6732,7.1476,20.5083,12.603,32.0505,16.0884,2.6014-3.4854,4.8998-7.1981,6.8698-11.0623-3.738-1.3891-7.3497-3.1318-10.8098-5.1523.9092-.6567,1.7932-1.3386,2.6519-1.9953,20.281,9.547,43.7696,9.547,64.0758,0,.8587.7072,1.7427,1.3891,2.6519,1.9953-3.4601,2.0457-7.0718,3.7632-10.835,5.1776,1.97,3.8642,4.2683,7.5769,6.8698,11.0623,11.5419-3.4854,22.3769-8.9156,32.0509-16.0631,2.626-27.2771-4.496-50.9172-18.817-71.8548C98.9811,4.2684,90.1918,1.5659,81.1752.0505l-.0252-.0505ZM42.2802,65.4144c-6.2383,0-11.4159-5.6575-11.4159-12.6535s4.9755-12.6788,11.3907-12.6788,11.5169,5.708,11.4159,12.6788c-.101,6.9708-5.026,12.6535-11.3907,12.6535ZM84.3576,65.4144c-6.2637,0-11.3907-5.6575-11.3907-12.6535s4.9755-12.6788,11.3907-12.6788,11.4917,5.708,11.3906,12.6788c-.101,6.9708-5.026,12.6535-11.3906,12.6535Z" />,
+    "fill"
+  );
+
+// GitHub - real octocat mark (currentColor)
+export const GithubIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 40 40",
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M19.9929 1C15.2745 1.00245 10.7108 2.6736 7.11792 5.71465C3.52501 8.75569 1.13714 12.9683 0.381282 17.5993C-0.374577 22.2302 0.550855 26.9775 2.99212 30.9923C5.43339 35.007 9.23128 38.0275 13.7067 39.5135C14.6941 39.6967 15.066 39.0848 15.066 38.5645C15.066 38.0442 15.0462 36.5356 15.0396 34.8862C9.51046 36.0807 8.3421 32.553 8.3421 32.553C7.44032 30.2623 6.13701 29.6601 6.13701 29.6601C4.33345 28.4362 6.27196 28.4591 6.27196 28.4591C8.2697 28.5999 9.31959 30.4979 9.31959 30.4979C11.0902 33.5184 13.97 32.6446 15.1022 32.1341C15.2799 30.8546 15.7966 29.9841 16.366 29.49C11.9492 28.9926 7.30867 27.2974 7.30867 19.725C7.2813 17.7611 8.01422 15.8619 9.35579 14.4203C9.15174 13.9229 8.47045 11.9136 9.54996 9.1844C9.54996 9.1844 11.2186 8.65427 15.0166 11.2101C18.2743 10.3242 21.7114 10.3242 24.9691 11.2101C28.7638 8.65427 30.4291 9.1844 30.4291 9.1844C31.5119 11.9071 30.8307 13.9164 30.6266 14.4203C31.9724 15.8621 32.7069 17.7646 32.677 19.7315C32.677 27.3203 28.0266 28.9926 23.6033 29.4801C24.3142 30.0954 24.9494 31.2964 24.9494 33.142C24.9494 35.7862 24.9263 37.9133 24.9263 38.5645C24.9263 39.0913 25.285 39.7066 26.2921 39.5135C30.7681 38.0273 34.5664 35.0063 37.0076 30.9909C39.4488 26.9754 40.3738 22.2274 39.617 17.596C38.8603 12.9647 36.4713 8.75199 32.8772 5.71147C29.2831 2.67095 24.7184 1.0009 19.9994 1H19.9929Z"
+    />,
+    "fill"
+  );
+
+// Google - monochrome "G" mark, currentColor (real asset is 4-color)
+export const GoogleIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 24 24",
+    <path d="M21.5 12.2c0-.7-.06-1.4-.18-2.05H12v3.88h5.34a4.57 4.57 0 0 1-1.98 3v2.5h3.2c1.87-1.73 2.94-4.28 2.94-7.33Z M12 22c2.7 0 4.96-.9 6.62-2.42l-3.2-2.5c-.9.6-2.04.95-3.42.95-2.63 0-4.86-1.78-5.66-4.17H3.04v2.58A10 10 0 0 0 12 22Z M6.34 13.86A6 6 0 0 1 6.02 12c0-.64.11-1.27.32-1.86V7.56H3.04A10 10 0 0 0 2 12c0 1.61.39 3.14 1.04 4.44l3.3-2.58Z M12 5.98c1.48 0 2.8.51 3.85 1.5l2.84-2.84A10 10 0 0 0 12 2 10 10 0 0 0 3.04 7.56l3.3 2.58C7.14 7.76 9.37 5.98 12 5.98Z" />,
+    "fill"
+  );
+
+// LinkedIn - real "in" mark (brand blue -> currentColor, disc rendered as ring)
+export const LinkedinIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 48 48",
+    <path d="M14 19H18V34H14zM15.988 17h-.022C14.772 17 14 16.11 14 14.999 14 13.864 14.796 13 16.011 13c1.217 0 1.966.864 1.989 1.999C18 16.11 17.228 17 15.988 17zM35 24.5c0-3.038-2.462-5.5-5.5-5.5-1.862 0-3.505.928-4.5 2.344V19h-4v15h4v-8c0-1.657 1.343-3 3-3s3 1.343 3 3v8h4C35 34 35 24.921 35 24.5z" />,
+    "fill"
+  );
+
+// X - real xStampIcon.svg (currentColor)
+export const XIcon: React.FC<IconProps> = ({ size = 22 }) =>
+  box(
+    size,
+    "0 0 48 48",
+    <path d="M36.6526 3.80762H43.3995L28.6594 20.6548L46 43.5797H32.4225L21.7881 29.6759L9.61989 43.5797H2.86886L18.6349 25.5599L2 3.80762H15.9222L25.5348 16.5165L36.6526 3.80762ZM34.2846 39.5414H38.0232L13.8908 7.63388H9.87892L34.2846 39.5414Z" />,
+    "fill"
+  );
+
+/* ---- category icons (the real BASE_PLATFORM_CATEGORIES glyphs, currentColor) ---- */
+
+const catSvg = (children: React.ReactNode, size: number) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="16 16 33 33"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2.4}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {children}
+  </svg>
+);
+
+// Physical Verification - the id-card glyph
+export const PhysicalCatIcon: React.FC<IconProps> = ({ size = 18 }) =>
+  catSvg(
+    <path d="M37.8332 29.6647H40.4998M37.8332 34.998H40.4998M24.7265 36.3314C25.0014 35.5501 25.512 34.8733 26.1879 34.3946C26.8638 33.9159 27.6716 33.6588 28.4998 33.6588C29.3281 33.6588 30.1359 33.9159 30.8118 34.3946C31.4877 34.8733 31.9983 35.5501 32.2732 36.3314M31.1665 30.998C31.1665 32.4708 29.9726 33.6647 28.4998 33.6647C27.0271 33.6647 25.8332 32.4708 25.8332 30.998C25.8332 29.5253 27.0271 28.3314 28.4998 28.3314C29.9726 28.3314 31.1665 29.5253 31.1665 30.998ZM21.8332 22.998H43.1665C44.6393 22.998 45.8332 24.192 45.8332 25.6647V38.998C45.8332 40.4708 44.6393 41.6647 43.1665 41.6647H21.8332C20.3604 41.6647 19.1665 40.4708 19.1665 38.998V25.6647C19.1665 24.192 20.3604 22.998 21.8332 22.998Z" />,
+    size
+  );
+
+// Blockchain Networks and Activities - the globe glyph
+export const BlockchainCatIcon: React.FC<IconProps> = ({ size = 18 }) =>
+  catSvg(
+    <path d="M45.8332 32.3314C45.8332 39.6952 39.8636 45.6647 32.4998 45.6647M45.8332 32.3314C45.8332 24.9676 39.8636 18.998 32.4998 18.998M45.8332 32.3314H19.1665M32.4998 45.6647C25.136 45.6647 19.1665 39.6952 19.1665 32.3314M32.4998 45.6647C29.0762 42.0698 27.1665 37.2957 27.1665 32.3314C27.1665 27.367 29.0762 22.5929 32.4998 18.998M32.4998 45.6647C35.9235 42.0698 37.8332 37.2957 37.8332 32.3314C37.8332 27.367 35.9235 22.5929 32.4998 18.998M19.1665 32.3314C19.1665 24.9676 25.136 18.998 32.4998 18.998" />,
+    size
+  );
+
+// Web2 Platforms & Services - the person-in-circle glyph
+export const Web2CatIcon: React.FC<IconProps> = ({ size = 18 }) =>
+  catSvg(
+    <path d="M40.4998 42.998C40.4998 40.8763 39.657 38.8415 38.1567 37.3412C36.6564 35.8409 34.6216 34.998 32.4998 34.998M32.4998 34.998C30.3781 34.998 28.3433 35.8409 26.843 37.3412C25.3427 38.8415 24.4998 40.8763 24.4998 42.998M32.4998 34.998C35.4454 34.998 37.8332 32.6102 37.8332 29.6647C37.8332 26.7192 35.4454 24.3314 32.4998 24.3314C29.5543 24.3314 27.1665 26.7192 27.1665 29.6647C27.1665 32.6102 29.5543 34.998 32.4998 34.998ZM45.8332 32.3314C45.8332 39.6952 39.8636 45.6647 32.4998 45.6647C25.136 45.6647 19.1665 39.6952 19.1665 32.3314C19.1665 24.9676 25.136 18.998 32.4998 18.998C39.8636 18.998 45.8332 24.9676 45.8332 32.3314Z" />,
+    size
+  );
+
+/** Category glyphs keyed by the verbatim category name. */
+export const CATEGORY_ICONS: Record<string, React.ReactNode> = {
+  "Physical Verification": <PhysicalCatIcon />,
+  "Blockchain Networks and Activities": <BlockchainCatIcon />,
+  "Web2 Platforms & Services": <Web2CatIcon />,
+};
+
+/**
+ * Every catalog platform's icon, keyed by the platform id used in the mock
+ * catalog + the drawer detail map (matches passport's platform ids).
+ */
+export const STAMP_ICONS: Record<string, React.ReactNode> = {
+  // Physical Verification
+  Binance: <BinanceIcon />,
+  Biometrics: <BiometricsIcon />,
+  Civic: <CivicIcon />,
+  CleanHands: <CleanHandsIcon />,
+  Coinbase: <CoinbaseIcon />,
+  HumanIdKyc: <GovIdIcon />,
+  HumanIdPhone: <PhoneIcon />,
+  // Blockchain Networks and Activities
+  Ens: <EnsIcon />,
+  ETH: <EthIcon />,
+  Gitcoin: <GitcoinIcon />,
+  GtcStaking: <GtcStakingIcon />,
+  NFT: <NftIcon />,
+  GuildXYZ: <GuildIcon />,
+  Lens: <LensIcon />,
+  Snapshot: <SnapshotIcon />,
+  GnosisSafe: <SafeIcon />,
+  Brightid: <BrightIdIcon />,
+  Idena: <IdenaIcon />,
+  ZkSync: <ZkSyncIcon />,
+  // Web2 Platforms & Services
+  Discord: <DiscordIcon />,
+  Github: <GithubIcon />,
+  Google: <GoogleIcon />,
+  Linkedin: <LinkedinIcon />,
+  X: <XIcon />,
+};

--- a/src/redesign/stampIcons.tsx
+++ b/src/redesign/stampIcons.tsx
@@ -315,6 +315,29 @@ export const XIcon: React.FC<IconProps> = ({ size = 22 }) =>
     "fill"
   );
 
+/* ---- chain marks ---- */
+
+// Optimism (OP Mainnet) logomark, redrawn monochrome (currentColor). The real
+// brand mark is a red disc carrying a soft "O"; here the disc plus the ring-notch
+// negative space reads as the Optimism mark on any surface without its brand red.
+// Used as the chain glyph on the drawer's onchain-credential block.
+export const OptimismIcon: React.FC<IconProps> = ({ size = 14 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M12 1.5C6.201 1.5 1.5 6.201 1.5 12S6.201 22.5 12 22.5 22.5 17.799 22.5 12 17.799 1.5 12 1.5ZM9.05 9.2c-1.62 0-2.77.86-3.06 2.36-.06.3-.09.55-.09.79 0 1.2.83 1.95 2.3 1.95 1.62 0 2.76-.86 3.06-2.36.05-.26.08-.52.08-.78 0-1.22-.82-1.96-2.29-1.96Zm-.72 3.06c-.5 0-.83-.27-.83-.75 0-.13.01-.27.04-.4.16-.78.6-1.11 1.19-1.11.5 0 .83.27.83.76 0 .13-.02.26-.04.39-.15.79-.6 1.11-1.19 1.11Zm5.9-3h-2.06l-.98 4.9h1.03l.33-1.66h1.05c1.32 0 2.19-.61 2.42-1.75.02-.12.04-.24.04-.35 0-.72-.55-1.14-1.6-1.14Zm.52 1.28-.02.16c-.1.47-.43.6-.93.6h-.79l.25-1.24h.83c.44 0 .66.14.66.42v.06Z"
+    />
+  </svg>
+);
+
 /* ---- category icons (the real BASE_PLATFORM_CATEGORIES glyphs, currentColor) ---- */
 
 const catSvg = (children: React.ReactNode, size: number) => (

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Widget, PassportWidgetTheme } from "../widgets/Widget";
 import { DarkTheme, LightTheme } from "../utils/themes";
-import type { StampDetail } from "./StampDetailDrawer";
+import type { Stamp } from "./StampsWindow";
+import type { StampComponent, StampDetail } from "./StampDetailDrawer";
+import { STAMP_ICONS } from "./stampIcons";
+import { daysFromNow } from "./expiry";
 
 /**
  * Story-only harness. Renders the redesign components inside the REAL widget
@@ -118,167 +121,410 @@ export const SAMPLE_STAMPS = [
   { id: "onchain", label: "On-chain", points: 3 },
 ];
 
-// Medallion-stamp sample data for the Stamps window. A mix of verified /
-// unverified and minted / mintable / off-chain so every face state is visible.
-// Two categories (three each) so it reads as a full grid on one page. Icons are
-// plain emoji (valid ReactNode) so the stories need no asset pipeline.
-export const SAMPLE_MEDALLION_STAMPS = [
-  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
-  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
-  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
-  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
-  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
-  { id: "x-social", name: "X", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "✖️" },
-];
+// Verbatim Passport category names (from usePlatforms.tsx BASE_PLATFORM_CATEGORIES).
+const CAT_PHYSICAL = "Physical Verification";
+const CAT_CHAIN = "Blockchain Networks and Activities";
+const CAT_WEB2 = "Web2 Platforms & Services";
 
-// A larger catalog that spills past one page (>6), so pagination shows two pages
-// with dots + arrows and the "never scrolled" rule is visible.
-export const SAMPLE_MEDALLION_STAMPS_PAGED = [
-  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
-  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
-  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
-  { id: "biometric", name: "Biometric", category: "Biometrics", points: 5, verified: true, onchain: "minted" as const, icon: "🫆" },
-  { id: "face-scan", name: "Face scan", category: "Biometrics", points: 4, verified: false, onchain: "none" as const, icon: "🙂" },
-  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
-  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
-  { id: "linkedin", name: "LinkedIn", category: "Social", points: 2, verified: false, onchain: "none" as const, icon: "🔗" },
-  { id: "eth-activity", name: "Ethereum activity", category: "On-chain activity", points: 4, verified: true, onchain: "mintable" as const, icon: "⟠" },
-  { id: "gitcoin", name: "Gitcoin", category: "On-chain activity", points: 3, verified: false, onchain: "none" as const, icon: "🌱" },
-];
-
-// Stamp-detail (drawer) sample data, keyed by the medallion stamp id so a Stamps
-// window story can open the drawer for whichever medallion is tapped. Each detail
-// extends its medallion stamp with the components used to score it (verified ones
-// sum to the header total) and a plain description. A spread of states so every
-// action is visible: minted (View on chain), mintable (Mint reward), unverified
-// (Claim), off-chain verified (Verified / done), and a 6-component paginated case.
-export const SAMPLE_STAMP_DETAILS: Record<string, StampDetail> = {
-  // Verified + minted -> View on chain. Three verified components summing to 6.
-  "gov-id": {
-    id: "gov-id",
+/**
+ * The REAL Human Passport stamp catalog for the redesign stories. Names, weights,
+ * categories, and icons all come from passportxyz/passport (platform Providers
+ * config + BASE_PLATFORM_CATEGORIES). `id` is the platform id; `icon` is the real
+ * platform SVG (currentColor). A spread of states so every face + navigation reads:
+ * verified / unverified, minted / mintable / off-chain, valid / expiring-soon /
+ * expired. `expirationDate` is present on verified stamps (a stamp expires as a
+ * whole; default lifetime is 90 days). `isHumanId` flags the SBT stamps.
+ */
+export const SAMPLE_MEDALLION_STAMPS: Stamp[] = [
+  // ---- Physical Verification ----
+  {
+    id: "HumanIdKyc",
     name: "Government ID",
-    category: "Identity",
-    points: 6,
+    category: CAT_PHYSICAL,
+    points: 16,
     verified: true,
     onchain: "minted",
-    icon: "🪪",
-    description: "Proof that a government issued ID checked out, without revealing the document.",
-    components: [
-      { name: "Document authenticity", points: 3, verified: true, expiry: "Renews Mar 2027", icon: "📄" },
-      { name: "Liveness check", points: 2, verified: true, icon: "🙂" },
-      { name: "Name match", points: 1, verified: true, icon: "🔤" },
-    ],
+    icon: STAMP_ICONS.HumanIdKyc,
+    isHumanId: true,
+    expirationDate: daysFromNow(78),
   },
-
-  // Verified + mintable -> Mint reward (gold CTA). This is the Clean Hands SBT.
-  "clean-hands": {
-    id: "clean-hands",
-    name: "Clean Hands",
-    category: "Identity",
-    points: 5,
+  {
+    id: "Biometrics",
+    name: "Biometrics",
+    category: CAT_PHYSICAL,
+    points: 6,
     verified: true,
     onchain: "mintable",
-    icon: "🤝",
-    description: "Proof that your wallet is clear of sanctions and watchlists.",
-    components: [
-      { name: "Sanctions check", points: 3, verified: true, expiry: "Renews Sep 1", icon: "🛡️" },
-      { name: "Watchlist check", points: 2, verified: true, icon: "🔎" },
-    ],
+    icon: STAMP_ICONS.Biometrics,
+    isHumanId: true,
+    expirationDate: daysFromNow(88),
   },
-
-  // Verified + mintable biometric -> Mint reward. Distinct from Clean Hands so the
-  // Mint story and the Clean Hands story show different stamps.
-  biometric: {
-    id: "biometric",
-    name: "Biometric",
-    category: "Biometrics",
-    points: 5,
+  {
+    id: "Civic",
+    name: "Civic",
+    category: CAT_PHYSICAL,
+    points: 8.86,
+    verified: true,
+    onchain: "none",
+    icon: STAMP_ICONS.Civic,
+    expirationDate: daysFromNow(9),
+  },
+  {
+    id: "CleanHands",
+    name: "Proof of Clean Hands",
+    category: CAT_PHYSICAL,
+    points: 3,
     verified: true,
     onchain: "mintable",
-    icon: "🫆",
-    description: "Proof of a unique, live human, checked with your camera.",
-    components: [
-      { name: "Face liveness", points: 3, verified: true, icon: "🙂" },
-      { name: "Uniqueness check", points: 2, verified: true, expiry: "Renews Aug 12", icon: "✨" },
-    ],
+    icon: STAMP_ICONS.CleanHands,
+    isHumanId: true,
+    expirationDate: daysFromNow(83),
   },
-
-  // Unverified -> Claim. Both components still missing (earns 0 until claimed).
-  phone: {
-    id: "phone",
-    name: "Phone",
-    category: "Identity",
-    points: 2,
+  {
+    id: "Coinbase",
+    name: "Coinbase",
+    category: CAT_PHYSICAL,
+    points: 16,
     verified: false,
     onchain: "none",
-    icon: "📱",
-    description: "Verify a phone number you control to add points.",
-    components: [
-      { name: "Phone ownership", points: 2, verified: false, icon: "📱" },
-      { name: "Carrier check", points: 1, verified: false, icon: "📶" },
-    ],
+    icon: STAMP_ICONS.Coinbase,
+  },
+  {
+    id: "HumanIdPhone",
+    name: "Phone Verification",
+    category: CAT_PHYSICAL,
+    points: 1.5,
+    verified: true,
+    onchain: "mintable",
+    icon: STAMP_ICONS.HumanIdPhone,
+    isHumanId: true,
+    expirationDate: daysFromNow(88),
+  },
+  {
+    id: "Binance",
+    name: "Binance",
+    category: CAT_PHYSICAL,
+    points: 16,
+    verified: true,
+    onchain: "none",
+    icon: STAMP_ICONS.Binance,
+    expirationDate: daysFromNow(62),
   },
 
-  // Verified but off-chain with nothing to mint -> the Verified (done) state.
-  github: {
-    id: "github",
+  // ---- Blockchain Networks and Activities ----
+  {
+    id: "Ens",
+    name: "ENS",
+    category: CAT_CHAIN,
+    points: 2,
+    verified: true,
+    onchain: "none",
+    icon: STAMP_ICONS.Ens,
+    expirationDate: daysFromNow(40),
+  },
+  {
+    id: "ETH",
+    name: "Ethereum",
+    category: CAT_CHAIN,
+    points: 2,
+    verified: true,
+    onchain: "none",
+    icon: STAMP_ICONS.ETH,
+    expirationDate: daysFromNow(21),
+  },
+  {
+    id: "Gitcoin",
+    name: "Gitcoin Grants",
+    category: CAT_CHAIN,
+    points: 2.5,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Gitcoin,
+  },
+  {
+    id: "GtcStaking",
+    name: "Identity Staking",
+    category: CAT_CHAIN,
+    points: 2.7,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.GtcStaking,
+  },
+  {
+    // A verified stamp whose credential has lapsed: the expired visual state.
+    id: "NFT",
+    name: "NFT",
+    category: CAT_CHAIN,
+    points: 2,
+    verified: true,
+    onchain: "none",
+    icon: STAMP_ICONS.NFT,
+    expirationDate: daysFromNow(-3),
+  },
+  {
+    id: "GuildXYZ",
+    name: "Guild.xyz",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.GuildXYZ,
+  },
+  {
+    id: "Lens",
+    name: "Lens",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Lens,
+  },
+  {
+    id: "Snapshot",
+    name: "Snapshot",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Snapshot,
+  },
+  {
+    id: "GnosisSafe",
+    name: "Safe",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.GnosisSafe,
+  },
+  {
+    id: "Brightid",
+    name: "BrightID",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Brightid,
+  },
+  {
+    id: "Idena",
+    name: "Idena",
+    category: CAT_CHAIN,
+    points: 1.5,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Idena,
+  },
+  {
+    id: "ZkSync",
+    name: "zkSync",
+    category: CAT_CHAIN,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.ZkSync,
+  },
+
+  // ---- Web2 Platforms & Services ----
+  {
+    id: "Discord",
+    name: "Discord",
+    category: CAT_WEB2,
+    points: 0.5,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Discord,
+  },
+  {
+    id: "Github",
     name: "GitHub",
-    category: "Social",
+    category: CAT_WEB2,
     points: 3,
     verified: true,
     onchain: "none",
-    icon: "🐙",
-    description: "Proof of an established GitHub account.",
-    components: [
-      { name: "Account age", points: 2, verified: true, expiry: "Renews Jun 2026", icon: "📆" },
-      { name: "Contribution history", points: 1, verified: true, icon: "📈" },
-    ],
+    icon: STAMP_ICONS.Github,
+    expirationDate: daysFromNow(55),
   },
-
-  // Unverified social -> Claim (single component).
-  discord: {
-    id: "discord",
-    name: "Discord",
-    category: "Social",
+  {
+    id: "Google",
+    name: "Google",
+    category: CAT_WEB2,
     points: 1,
-    verified: false,
-    onchain: "none",
-    icon: "💬",
-    description: "Verify a Discord account to add a point.",
-    components: [{ name: "Account ownership", points: 1, verified: false, icon: "💬" }],
-  },
-
-  // Unverified social -> Claim (single component).
-  "x-social": {
-    id: "x-social",
-    name: "X",
-    category: "Social",
-    points: 1,
-    verified: false,
-    onchain: "none",
-    icon: "✖️",
-    description: "Verify an X account to add a point.",
-    components: [{ name: "Account ownership", points: 1, verified: false, icon: "✖️" }],
-  },
-
-  // Minted with SIX components -> the paginated-components case (View on chain).
-  // Three verified (sum to 5) plus three still-available, across two pages.
-  reputation: {
-    id: "reputation",
-    name: "On-chain reputation",
-    category: "On-chain activity",
-    points: 5,
     verified: true,
-    onchain: "minted",
-    icon: "⟠",
-    description: "Proof of a real, active on-chain history.",
+    onchain: "none",
+    icon: STAMP_ICONS.Google,
+    expirationDate: daysFromNow(12),
+  },
+  {
+    id: "Linkedin",
+    name: "LinkedIn",
+    category: CAT_WEB2,
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.Linkedin,
+  },
+  {
+    id: "X",
+    name: "X",
+    category: CAT_WEB2,
+    points: 2,
+    verified: false,
+    onchain: "none",
+    icon: STAMP_ICONS.X,
+  },
+];
+
+// The full catalog already spills each category past one page (Physical 7,
+// Blockchain 12), so category nav + within-category paging both read from it.
+export const SAMPLE_MEDALLION_STAMPS_PAGED = SAMPLE_MEDALLION_STAMPS;
+
+/**
+ * Per-stamp detail payload: real description + the sub-credential components used
+ * to score it. Single-credential platforms (including every Human ID SBT) list
+ * one component; multi-component platforms (Civic, Ethereum, NFT, Gitcoin,
+ * Identity Staking, GitHub) list several. Verified components sum to the header
+ * total; unverified list what is still available. Values mirror passport's real
+ * providers (e.g. Civic Captcha 0.82 + Uniqueness 5.0 + Liveness 3.04 = 8.86).
+ */
+const DETAIL_META: Record<string, { description: string; components: StampComponent[] }> = {
+  HumanIdKyc: {
+    description:
+      "Complete identity verification using a government issued ID to prove uniqueness while keeping your details private.",
+    components: [{ name: "Government ID Holder", points: 16, verified: true }],
+  },
+  Biometrics: {
+    description: "Proves unique humanity through 3D facial liveness verification and deduplication.",
+    components: [{ name: "Unique Biometric Identity", points: 6, verified: true }],
+  },
+  Civic: {
+    description: "Connect to Civic to verify your identity across CAPTCHA, uniqueness, and liveness checks.",
     components: [
-      { name: "Account age", points: 2, verified: true, expiry: "Renews Jan 2027", icon: "📆" },
-      { name: "Transaction history", points: 2, verified: true, icon: "🔁" },
-      { name: "Token holdings", points: 1, verified: true, icon: "🪙" },
-      { name: "NFT activity", points: 1, verified: false, icon: "🖼️" },
-      { name: "DeFi activity", points: 1, verified: false, icon: "🏦" },
-      { name: "Governance votes", points: 1, verified: false, icon: "🗳️" },
+      { name: "Civic CAPTCHA Pass", points: 0.82, verified: true },
+      { name: "Civic Uniqueness Pass", points: 5.0, verified: true },
+      { name: "Civic Liveness Pass", points: 3.04, verified: true },
     ],
+  },
+  CleanHands: {
+    description:
+      "Awarded after completing identity verification and sanctions validation, strengthening your proof of humanity.",
+    components: [{ name: "Sanctions-Free Identity Verified", points: 3, verified: true }],
+  },
+  Coinbase: {
+    description: "Verify your Coinbase account and onchain ID to link a trusted, verified exchange account.",
+    components: [{ name: "Coinbase KYC Verified", points: 16, verified: false }],
+  },
+  HumanIdPhone: {
+    description: "Confirm ownership of a unique phone number to prove a real human.",
+    components: [{ name: "Verified Phone Number", points: 1.5, verified: true }],
+  },
+  Binance: {
+    description:
+      "Verify KYC with your Binance Account Bound Token, proving you completed identity verification on Binance.",
+    components: [{ name: "Binance Account Bound Token (BABT)", points: 16, verified: true }],
+  },
+  Ens: {
+    description: "Own and configure an ENS domain as your primary name to establish a decentralized identity.",
+    components: [{ name: "ENS Domain Owner", points: 2, verified: true }],
+  },
+  ETH: {
+    description: "Verify your Ethereum mainnet and L2 transaction history for genuine network participation.",
+    components: [
+      { name: "ETH Enthusiast", points: 1, verified: true },
+      { name: "Execute over 100 transactions", points: 0.5, verified: true },
+      { name: "Active on over 50 distinct days", points: 0.5, verified: true },
+    ],
+  },
+  Gitcoin: {
+    description: "Verify your Gitcoin Grants donations to official rounds.",
+    components: [
+      { name: "Bronze Contributor", points: 1, verified: false },
+      { name: "Silver Contributor", points: 1.5, verified: false },
+    ],
+  },
+  GtcStaking: {
+    description: "Stake GTC on yourself or others to boost trust in the ecosystem.",
+    components: [
+      { name: "Bronze Staker", points: 1.2, verified: false },
+      { name: "Community Participant", points: 1.5, verified: false },
+    ],
+  },
+  NFT: {
+    description: "Verify your Ethereum L1 NFT collection and holdings.",
+    components: [
+      { name: "Digital Collector", points: 1, verified: true },
+      { name: "Holds at least 1 NFT (ERC-721)", points: 1, verified: true },
+    ],
+  },
+  GuildXYZ: {
+    description: "Verify membership in your Guild.xyz communities.",
+    components: [{ name: "Guild Member", points: 1, verified: false }],
+  },
+  Lens: {
+    description: "Verify ownership of your Lens Protocol handle.",
+    components: [{ name: "Lens Handle Owner", points: 1, verified: false }],
+  },
+  Snapshot: {
+    description: "Verify your participation in Snapshot governance votes.",
+    components: [{ name: "Snapshot Voter", points: 1, verified: false }],
+  },
+  GnosisSafe: {
+    description: "Verify that you are a signer on a Safe multisig wallet.",
+    components: [{ name: "Safe Signer", points: 1, verified: false }],
+  },
+  Brightid: {
+    description: "Verify your BrightID to prove a unique social identity.",
+    components: [{ name: "BrightID Verified", points: 1, verified: false }],
+  },
+  Idena: {
+    description: "Verify your Idena proof of person validation status.",
+    components: [{ name: "Idena Validated", points: 1.5, verified: false }],
+  },
+  ZkSync: {
+    description: "Verify your zkSync Era transaction history.",
+    components: [{ name: "zkSync Era Activity", points: 1, verified: false }],
+  },
+  Discord: {
+    description: "Verify genuine Discord engagement and Sybil resistance.",
+    components: [{ name: "Discord Engagement Verification", points: 0.5, verified: false }],
+  },
+  Github: {
+    description: "Verify your GitHub activity through a sustained contribution history.",
+    components: [
+      { name: "Regular Contributor", points: 2, verified: true },
+      { name: "Active Developer", points: 1, verified: true },
+    ],
+  },
+  Google: {
+    description: "Connect and verify ownership of your Google account.",
+    components: [{ name: "Verify Google Account Ownership", points: 1, verified: true }],
+  },
+  Linkedin: {
+    description: "Connect and verify ownership of your LinkedIn account.",
+    components: [{ name: "Verify LinkedIn Account Ownership", points: 1, verified: false }],
+  },
+  X: {
+    description: "Verify your X account, including verified status, followers, and account age.",
+    components: [{ name: "Verify X Verified Account", points: 2, verified: false }],
   },
 };
+
+/**
+ * Presentational join: the catalog `Stamp` (icons / weights / category / expiry /
+ * on-chain, from the metadata + score endpoints) merged with its scoring
+ * components, keyed by stamp id. This is the exact shape the drawer takes via props.
+ */
+export const SAMPLE_STAMP_DETAILS: Record<string, StampDetail> = SAMPLE_MEDALLION_STAMPS.reduce(
+  (acc, stamp) => {
+    const meta = DETAIL_META[stamp.id];
+    acc[stamp.id] = {
+      ...stamp,
+      description: meta?.description,
+      components: meta?.components ?? [
+        { name: stamp.name, points: stamp.points, verified: stamp.verified },
+      ],
+    };
+    return acc;
+  },
+  {} as Record<string, StampDetail>
+);

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -519,6 +519,42 @@ export const SAMPLE_MEDALLION_STAMPS: Stamp[] = MEDALLION_BASE.map((s) => ({
 // Blockchain 12), so category nav + within-category paging both read from it.
 export const SAMPLE_MEDALLION_STAMPS_PAGED = SAMPLE_MEDALLION_STAMPS;
 
+// ---- Onchain credential block, Human ID SBT stamps only (all non-PII). ----
+// The HubV3 SBT contract on Optimism; Proof of Clean Hands points at its Sign
+// Protocol attestation. In production these fields come from the Human ID SDK
+// getters (already fetched in useHumanIDVerification and discarded); here we seed
+// the same non-PII shape. No nullifier / indexingValue, no fake tokenId.
+const HUB_V3 = "0x2AA822e264F8cc31A2b9C22f39e5551241e94DfB";
+const OP_CONTRACT_URL = `https://optimistic.etherscan.io/address/${HUB_V3}`;
+const HUMAN_ID_ONCHAIN: Record<string, { credential: string; explorerUrl: string }> = {
+  HumanIdKyc: { credential: "Government ID", explorerUrl: OP_CONTRACT_URL },
+  Biometrics: { credential: "Biometrics", explorerUrl: OP_CONTRACT_URL },
+  HumanIdPhone: { credential: "Phone", explorerUrl: OP_CONTRACT_URL },
+  CleanHands: { credential: "Proof of Clean Hands", explorerUrl: "https://scan.sign.global/attestation" },
+};
+
+const ONE_DAY = 86_400_000;
+const fmtDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+
+const buildOnchain = (stamp: Stamp): StampDetail["onchainCredential"] => {
+  const oc = HUMAN_ID_ONCHAIN[stamp.id];
+  if (!oc) return undefined;
+  // Issued is derivable (SBT default lifetime is 90 days), so issued = expiry - 90d.
+  const issued = stamp.expirationDate
+    ? fmtDate(new Date(new Date(stamp.expirationDate).getTime() - 90 * ONE_DAY).toISOString())
+    : undefined;
+  return {
+    issued,
+    expires: stamp.expirationDate ? fmtDate(stamp.expirationDate) : undefined,
+    chain: "Optimism",
+    revoked: false,
+    credential: oc.credential,
+    issuer: "Human ID",
+    explorerUrl: oc.explorerUrl,
+  };
+};
+
 /**
  * Presentational join: the catalog `Stamp` (icons / weights / category / expiry /
  * on-chain, from the metadata + score endpoints) merged with its scoring
@@ -533,6 +569,7 @@ export const SAMPLE_STAMP_DETAILS: Record<string, StampDetail> = SAMPLE_MEDALLIO
       components: meta?.components ?? [
         { name: stamp.name, points: stamp.points, verified: stamp.verified },
       ],
+      onchainCredential: buildOnchain(stamp),
     };
     return acc;
   },

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -519,18 +519,42 @@ export const SAMPLE_MEDALLION_STAMPS: Stamp[] = MEDALLION_BASE.map((s) => ({
 // Blockchain 12), so category nav + within-category paging both read from it.
 export const SAMPLE_MEDALLION_STAMPS_PAGED = SAMPLE_MEDALLION_STAMPS;
 
-// ---- Onchain credential block, Human ID SBT stamps only (all non-PII). ----
-// The HubV3 SBT contract on Optimism; Proof of Clean Hands points at its Sign
-// Protocol attestation. In production these fields come from the Human ID SDK
-// getters (already fetched in useHumanIDVerification and discarded); here we seed
-// the same non-PII shape. No nullifier / indexingValue, no fake tokenId.
+// ---- Onchain credential block, Human ID SBT / attestation stamps only (all
+// non-PII). ----
+// The three Human ID SBTs (Government ID, Biometrics, Phone) live on the HubV3
+// contract on Optimism. Proof of Clean Hands is a SIGN PROTOCOL attestation (NOT
+// EAS), viewed on scan.sign.global; its attester is a distinct address. In
+// production these fields come from the Human ID SDK getters (already fetched in
+// useHumanIDVerification and discarded); here we seed the same non-PII shape. No
+// nullifier / indexingValue, no user address, no fake tokenId. The issuer renders
+// as the verified identity "human.tech", never a raw hex string, with a
+// view-on-chain link to the contract / attester.
 const HUB_V3 = "0x2AA822e264F8cc31A2b9C22f39e5551241e94DfB";
-const OP_CONTRACT_URL = `https://optimistic.etherscan.io/address/${HUB_V3}`;
-const HUMAN_ID_ONCHAIN: Record<string, { credential: string; explorerUrl: string }> = {
-  HumanIdKyc: { credential: "Government ID", explorerUrl: OP_CONTRACT_URL },
-  Biometrics: { credential: "Biometrics", explorerUrl: OP_CONTRACT_URL },
-  HumanIdPhone: { credential: "Phone", explorerUrl: OP_CONTRACT_URL },
-  CleanHands: { credential: "Proof of Clean Hands", explorerUrl: "https://scan.sign.global/attestation" },
+const CLEAN_HANDS_ATTESTER = "0xB1f50c6C34C72346b1229e5C80587D0D659556Fd";
+const opAddr = (address: string): string => `https://optimistic.etherscan.io/address/${address}`;
+// A representative Sign Protocol attestation id (shape: onchain_evm_10_0x…). It
+// is an on-chain handle, not PII; the nullifier / indexingValue is never shown.
+const CLEAN_HANDS_ATTESTATION_ID = "onchain_evm_10_0x7c9f2a4b8e1d6053";
+
+type OcSeed = {
+  protocol: "sbt" | "sign";
+  credential: string;
+  /** View the credential itself. */
+  explorerUrl: string;
+  /** View the verified issuer / attester on chain. */
+  issuerUrl: string;
+};
+
+const HUMAN_ID_ONCHAIN: Record<string, OcSeed> = {
+  HumanIdKyc: { protocol: "sbt", credential: "Government ID", explorerUrl: opAddr(HUB_V3), issuerUrl: opAddr(HUB_V3) },
+  Biometrics: { protocol: "sbt", credential: "Biometrics", explorerUrl: opAddr(HUB_V3), issuerUrl: opAddr(HUB_V3) },
+  HumanIdPhone: { protocol: "sbt", credential: "Phone", explorerUrl: opAddr(HUB_V3), issuerUrl: opAddr(HUB_V3) },
+  CleanHands: {
+    protocol: "sign",
+    credential: "Proof of Clean Hands",
+    explorerUrl: `https://scan.sign.global/attestation/${CLEAN_HANDS_ATTESTATION_ID}`,
+    issuerUrl: opAddr(CLEAN_HANDS_ATTESTER),
+  },
 };
 
 const ONE_DAY = 86_400_000;
@@ -541,16 +565,20 @@ const buildOnchain = (stamp: Stamp): StampDetail["onchainCredential"] => {
   const oc = HUMAN_ID_ONCHAIN[stamp.id];
   if (!oc) return undefined;
   // Issued is derivable (SBT default lifetime is 90 days), so issued = expiry - 90d.
+  // (Real getters: SBT expiry / attestation validUntil are seconds, attestTimestamp
+  // is ms; convert before formatting. Here the seed dates are already ISO.)
   const issued = stamp.expirationDate
     ? fmtDate(new Date(new Date(stamp.expirationDate).getTime() - 90 * ONE_DAY).toISOString())
     : undefined;
   return {
+    protocol: oc.protocol,
     issued,
     expires: stamp.expirationDate ? fmtDate(stamp.expirationDate) : undefined,
     chain: "Optimism",
     revoked: false,
     credential: oc.credential,
-    issuer: "Human ID",
+    issuer: "human.tech",
+    issuerUrl: oc.issuerUrl,
     explorerUrl: oc.explorerUrl,
   };
 };

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -116,3 +116,31 @@ export const SAMPLE_STAMPS = [
   { id: "social", label: "Social", points: 5 },
   { id: "onchain", label: "On-chain", points: 3 },
 ];
+
+// Medallion-stamp sample data for the Stamps window. A mix of verified /
+// unverified and minted / mintable / off-chain so every face state is visible.
+// Two categories (three each) so it reads as a full grid on one page. Icons are
+// plain emoji (valid ReactNode) so the stories need no asset pipeline.
+export const SAMPLE_MEDALLION_STAMPS = [
+  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
+  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
+  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
+  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
+  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
+  { id: "x-social", name: "X", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "✖️" },
+];
+
+// A larger catalog that spills past one page (>6), so pagination shows two pages
+// with dots + arrows and the "never scrolled" rule is visible.
+export const SAMPLE_MEDALLION_STAMPS_PAGED = [
+  { id: "gov-id", name: "Government ID", category: "Identity", points: 6, verified: true, onchain: "minted" as const, icon: "🪪" },
+  { id: "clean-hands", name: "Clean Hands", category: "Identity", points: 5, verified: true, onchain: "mintable" as const, icon: "🤝" },
+  { id: "phone", name: "Phone", category: "Identity", points: 2, verified: false, onchain: "none" as const, icon: "📱" },
+  { id: "biometric", name: "Biometric", category: "Biometrics", points: 5, verified: true, onchain: "minted" as const, icon: "🫆" },
+  { id: "face-scan", name: "Face scan", category: "Biometrics", points: 4, verified: false, onchain: "none" as const, icon: "🙂" },
+  { id: "github", name: "GitHub", category: "Social", points: 3, verified: true, onchain: "none" as const, icon: "🐙" },
+  { id: "discord", name: "Discord", category: "Social", points: 1, verified: false, onchain: "none" as const, icon: "💬" },
+  { id: "linkedin", name: "LinkedIn", category: "Social", points: 2, verified: false, onchain: "none" as const, icon: "🔗" },
+  { id: "eth-activity", name: "Ethereum activity", category: "On-chain activity", points: 4, verified: true, onchain: "mintable" as const, icon: "⟠" },
+  { id: "gitcoin", name: "Gitcoin", category: "On-chain activity", points: 3, verified: false, onchain: "none" as const, icon: "🌱" },
+];

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { Widget, PassportWidgetTheme } from "../widgets/Widget";
+import { DarkTheme, LightTheme } from "../utils/themes";
+
+/**
+ * Story-only harness. Renders the redesign components inside the REAL widget
+ * root (`Widget`) so the §1 token scope (--surface, --accent, --space-*, …) and
+ * the 300px sizing resolve exactly as they do in a host app - then places that
+ * widget on a light / dark HOST background to prove the "guest on any surface"
+ * rule (SOP §2 / §7). No network: Widget provides its own providers.
+ */
+
+const hostBg: Record<"light" | "dark", string> = {
+  light: "#eef0f4",
+  dark: "#0b0b10",
+};
+
+const Frame: React.FC<{ theme: PassportWidgetTheme; label: string; bg: "light" | "dark"; children: React.ReactNode }> = ({
+  theme,
+  label,
+  bg,
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10 }}>
+    <span
+      style={{
+        fontFamily: "ui-monospace, monospace",
+        fontSize: 11,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: bg === "dark" ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.5)",
+      }}
+    >
+      {label}
+    </span>
+    <div style={{ padding: 24, borderRadius: 20, background: hostBg[bg] }}>
+      <Widget theme={theme}>{children}</Widget>
+    </div>
+  </div>
+);
+
+/** Render the same content in both themes, side by side, each on a matching host background. */
+export const ThemePair: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div style={{ display: "flex", gap: 28, flexWrap: "wrap", alignItems: "flex-start" }}>
+    <Frame theme={LightTheme} label="Light theme · light host" bg="light">
+      {children}
+    </Frame>
+    <Frame theme={DarkTheme} label="Dark theme · dark host" bg="dark">
+      {children}
+    </Frame>
+  </div>
+);
+
+export const SAMPLE_ACCOUNT = {
+  display: "Shady.eth",
+  kind: "ENS",
+  email: "shady@holonym.id",
+  address: "0x1332…4a9f",
+  linkedWallets: [
+    // `address` carries the FULL value for the hover-to-copy control, while
+    // `display` stays truncated. Copying yields the complete address.
+    { display: "0x1332…4a9f", kind: "Wallet", address: "0x1332f4c1b9a70d5e2c8a4f6e11c9b3d0aa7e4a9f" },
+    { display: "vault.eth", kind: "ENS", address: "0x77aa20c3e9b1d4f60825ab19c7d3e5f0126b8c11" },
+  ],
+  accounts: [
+    { display: "Shady.eth", kind: "ENS" },
+    { display: "0x1332…4a9f", kind: "Wallet" },
+  ],
+};
+
+const BASE = { display: "Shady.eth", kind: "ENS", email: "shady@holonym.id", address: "0x1332…4a9f" };
+
+/** One linked wallet. */
+export const ACCOUNT_ONE_WALLET = {
+  ...BASE,
+  linkedWallets: [{ display: "0x1332…4a9f", kind: "Wallet" }],
+};
+
+/** Exactly three linked wallets (fills a page, no pager yet). */
+export const ACCOUNT_THREE_WALLETS = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet" },
+    { display: "vault.eth", kind: "ENS" },
+    { display: "0x88b1…02aa", kind: "Wallet" },
+  ],
+};
+
+/** Six linked wallets: paginates into two pages of three (dots + arrows). */
+export const ACCOUNT_SIX_WALLETS = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet" },
+    { display: "vault.eth", kind: "ENS" },
+    { display: "0x88b1…02aa", kind: "Wallet" },
+    { display: "treasury.eth", kind: "ENS" },
+    { display: "0x4c9d…7f10", kind: "Safe" },
+    { display: "0xab20…6d33", kind: "Wallet" },
+  ],
+};
+
+/** A mix including a wallet in cooldown and one still pending. */
+export const ACCOUNT_COOLDOWN = {
+  ...BASE,
+  linkedWallets: [
+    { display: "0x1332…4a9f", kind: "Wallet", status: "active" as const },
+    { display: "vault.eth", status: "cooldown" as const, cooldownUntil: "Cooldown until Aug 3" },
+    { display: "0x88b1…02aa", status: "pending" as const, cooldownUntil: "Linking in progress" },
+  ],
+};
+
+export const SAMPLE_STAMPS = [
+  { id: "gov-id", label: "Government ID", points: 6 },
+  { id: "biometric", label: "Biometric", points: 5 },
+  { id: "clean-hands", label: "Clean Hands", points: 5 },
+  { id: "social", label: "Social", points: 5 },
+  { id: "onchain", label: "On-chain", points: 3 },
+];

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -135,7 +135,7 @@ const CAT_WEB2 = "Web2 Platforms & Services";
  * expired. `expirationDate` is present on verified stamps (a stamp expires as a
  * whole; default lifetime is 90 days). `isHumanId` flags the SBT stamps.
  */
-export const SAMPLE_MEDALLION_STAMPS: Stamp[] = [
+const MEDALLION_BASE: Stamp[] = [
   // ---- Physical Verification ----
   {
     id: "HumanIdKyc",
@@ -375,10 +375,6 @@ export const SAMPLE_MEDALLION_STAMPS: Stamp[] = [
   },
 ];
 
-// The full catalog already spills each category past one page (Physical 7,
-// Blockchain 12), so category nav + within-category paging both read from it.
-export const SAMPLE_MEDALLION_STAMPS_PAGED = SAMPLE_MEDALLION_STAMPS;
-
 /**
  * Per-stamp detail payload: real description + the sub-credential components used
  * to score it. Single-credential platforms (including every Human ID SBT) list
@@ -508,6 +504,20 @@ const DETAIL_META: Record<string, { description: string; components: StampCompon
     components: [{ name: "Verify X Verified Account", points: 2, verified: false }],
   },
 };
+
+/**
+ * The catalog with each stamp's plain description attached (from DETAIL_META), so
+ * the grid medallion's hover / focus tooltip explains WHAT the stamp does. The
+ * drawer reuses the same description verbatim.
+ */
+export const SAMPLE_MEDALLION_STAMPS: Stamp[] = MEDALLION_BASE.map((s) => ({
+  ...s,
+  description: DETAIL_META[s.id]?.description,
+}));
+
+// The full catalog already spills each category past one page (Physical 7,
+// Blockchain 12), so category nav + within-category paging both read from it.
+export const SAMPLE_MEDALLION_STAMPS_PAGED = SAMPLE_MEDALLION_STAMPS;
 
 /**
  * Presentational join: the catalog `Stamp` (icons / weights / category / expiry /

--- a/src/redesign/storyFrame.tsx
+++ b/src/redesign/storyFrame.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Widget, PassportWidgetTheme } from "../widgets/Widget";
 import { DarkTheme, LightTheme } from "../utils/themes";
+import type { StampDetail } from "./StampDetailDrawer";
 
 /**
  * Story-only harness. Renders the redesign components inside the REAL widget
@@ -144,3 +145,140 @@ export const SAMPLE_MEDALLION_STAMPS_PAGED = [
   { id: "eth-activity", name: "Ethereum activity", category: "On-chain activity", points: 4, verified: true, onchain: "mintable" as const, icon: "⟠" },
   { id: "gitcoin", name: "Gitcoin", category: "On-chain activity", points: 3, verified: false, onchain: "none" as const, icon: "🌱" },
 ];
+
+// Stamp-detail (drawer) sample data, keyed by the medallion stamp id so a Stamps
+// window story can open the drawer for whichever medallion is tapped. Each detail
+// extends its medallion stamp with the components used to score it (verified ones
+// sum to the header total) and a plain description. A spread of states so every
+// action is visible: minted (View on chain), mintable (Mint reward), unverified
+// (Claim), off-chain verified (Verified / done), and a 6-component paginated case.
+export const SAMPLE_STAMP_DETAILS: Record<string, StampDetail> = {
+  // Verified + minted -> View on chain. Three verified components summing to 6.
+  "gov-id": {
+    id: "gov-id",
+    name: "Government ID",
+    category: "Identity",
+    points: 6,
+    verified: true,
+    onchain: "minted",
+    icon: "🪪",
+    description: "Proof that a government issued ID checked out, without revealing the document.",
+    components: [
+      { name: "Document authenticity", points: 3, verified: true, expiry: "Renews Mar 2027", icon: "📄" },
+      { name: "Liveness check", points: 2, verified: true, icon: "🙂" },
+      { name: "Name match", points: 1, verified: true, icon: "🔤" },
+    ],
+  },
+
+  // Verified + mintable -> Mint reward (gold CTA). This is the Clean Hands SBT.
+  "clean-hands": {
+    id: "clean-hands",
+    name: "Clean Hands",
+    category: "Identity",
+    points: 5,
+    verified: true,
+    onchain: "mintable",
+    icon: "🤝",
+    description: "Proof that your wallet is clear of sanctions and watchlists.",
+    components: [
+      { name: "Sanctions check", points: 3, verified: true, expiry: "Renews Sep 1", icon: "🛡️" },
+      { name: "Watchlist check", points: 2, verified: true, icon: "🔎" },
+    ],
+  },
+
+  // Verified + mintable biometric -> Mint reward. Distinct from Clean Hands so the
+  // Mint story and the Clean Hands story show different stamps.
+  biometric: {
+    id: "biometric",
+    name: "Biometric",
+    category: "Biometrics",
+    points: 5,
+    verified: true,
+    onchain: "mintable",
+    icon: "🫆",
+    description: "Proof of a unique, live human, checked with your camera.",
+    components: [
+      { name: "Face liveness", points: 3, verified: true, icon: "🙂" },
+      { name: "Uniqueness check", points: 2, verified: true, expiry: "Renews Aug 12", icon: "✨" },
+    ],
+  },
+
+  // Unverified -> Claim. Both components still missing (earns 0 until claimed).
+  phone: {
+    id: "phone",
+    name: "Phone",
+    category: "Identity",
+    points: 2,
+    verified: false,
+    onchain: "none",
+    icon: "📱",
+    description: "Verify a phone number you control to add points.",
+    components: [
+      { name: "Phone ownership", points: 2, verified: false, icon: "📱" },
+      { name: "Carrier check", points: 1, verified: false, icon: "📶" },
+    ],
+  },
+
+  // Verified but off-chain with nothing to mint -> the Verified (done) state.
+  github: {
+    id: "github",
+    name: "GitHub",
+    category: "Social",
+    points: 3,
+    verified: true,
+    onchain: "none",
+    icon: "🐙",
+    description: "Proof of an established GitHub account.",
+    components: [
+      { name: "Account age", points: 2, verified: true, expiry: "Renews Jun 2026", icon: "📆" },
+      { name: "Contribution history", points: 1, verified: true, icon: "📈" },
+    ],
+  },
+
+  // Unverified social -> Claim (single component).
+  discord: {
+    id: "discord",
+    name: "Discord",
+    category: "Social",
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: "💬",
+    description: "Verify a Discord account to add a point.",
+    components: [{ name: "Account ownership", points: 1, verified: false, icon: "💬" }],
+  },
+
+  // Unverified social -> Claim (single component).
+  "x-social": {
+    id: "x-social",
+    name: "X",
+    category: "Social",
+    points: 1,
+    verified: false,
+    onchain: "none",
+    icon: "✖️",
+    description: "Verify an X account to add a point.",
+    components: [{ name: "Account ownership", points: 1, verified: false, icon: "✖️" }],
+  },
+
+  // Minted with SIX components -> the paginated-components case (View on chain).
+  // Three verified (sum to 5) plus three still-available, across two pages.
+  reputation: {
+    id: "reputation",
+    name: "On-chain reputation",
+    category: "On-chain activity",
+    points: 5,
+    verified: true,
+    onchain: "minted",
+    icon: "⟠",
+    description: "Proof of a real, active on-chain history.",
+    components: [
+      { name: "Account age", points: 2, verified: true, expiry: "Renews Jan 2027", icon: "📆" },
+      { name: "Transaction history", points: 2, verified: true, icon: "🔁" },
+      { name: "Token holdings", points: 1, verified: true, icon: "🪙" },
+      { name: "NFT activity", points: 1, verified: false, icon: "🖼️" },
+      { name: "DeFi activity", points: 1, verified: false, icon: "🏦" },
+      { name: "Governance votes", points: 1, verified: false, icon: "🗳️" },
+    ],
+  },
+};

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -2,11 +2,15 @@ import { PassportWidgetTheme } from "../widgets/Widget";
 
 export const DarkTheme: PassportWidgetTheme = {
   colors: {
+    // Human Passport brand: emerald accent (#10B981) on a brand dark surface.
+    // Surface is an emerald-tinted charcoal (#101815), NOT pure black: brand
+    // Neutral-95 (#0A0A0A) warmed toward brand Emerald-95 (#064E3B). It reads as
+    // a deep on-brand surface and lets the emerald paper-shader wash show.
     primary: "255, 255, 255",
-    secondary: "109, 109, 109",
-    background: "0, 0, 0",
-    accent: "0, 212, 170",
-    error: "235, 48, 45",
+    secondary: "115, 115, 115",
+    background: "16, 24, 21",
+    accent: "16, 185, 129",
+    error: "252, 103, 100",
     white: "255, 255, 255",
     black: "0, 0, 0",
   },
@@ -38,12 +42,14 @@ export const DarkTheme: PassportWidgetTheme = {
 export const LightTheme: PassportWidgetTheme = {
   ...DarkTheme,
   colors: {
-    primary: "55, 55, 55",
-    secondary: "200, 200, 200",
+    // Human Passport brand emerald accent (#10B981). primary darkened to near-black
+    // (10,10,10) so secondary/muted text (rgba over primary) clears WCAG-AA ≥4.5:1
+    // on the white surface — previously 55,55,55 which failed at low alphas.
+    primary: "10, 10, 10",
+    secondary: "115, 115, 115",
     background: "255, 255, 255",
-    accent: "113, 248, 194",
-    // Real error red, legible on the light (white) surface. Previously 55,55,55
-    // (grey) which disagreed with the DarkTheme error and read as non-error.
+    accent: "16, 185, 129",
+    // Real error red, legible on the light (white) surface.
     error: "220, 38, 38",
   },
 };

--- a/src/widgets/PassportScoreWidget.stories.tsx
+++ b/src/widgets/PassportScoreWidget.stories.tsx
@@ -87,7 +87,7 @@ const openPlatform = async (root: HTMLElement, platformName: string) => {
 // surface platform variants the default handler doesn't expose (extra Human ID
 // credential types, a signature-only stamp). This overrides only the story's
 // MSW handler set, not the shared mocks.
-const stampsMetadataHandler = (pages: unknown) =>
+const stampsMetadataHandler = (pages: object) =>
   http.get(`${MOCK_SERVICE_URL}/embed/stamps/metadata`, async () => {
     await delay(200);
     return HttpResponse.json(pages);

--- a/src/widgets/Widget.module.css
+++ b/src/widgets/Widget.module.css
@@ -79,7 +79,10 @@
   /* Motion */
   --motion-fast-c6dbf459: 50ms;
   --motion-base-c6dbf459: 200ms;
-  --ease-standard-c6dbf459: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-slow-c6dbf459: 900ms;
+  /* House ease-out (§1/§4). Components inline this same curve; the token is the
+   * single source of truth so the two never drift. */
+  --ease-standard-c6dbf459: cubic-bezier(0.22, 1, 0.36, 1);
 
   /* ---------------------------------------------------------------------
    * Per-role color aliases. Future work overrides ONE semantic name and it
@@ -96,6 +99,31 @@
   --danger: var(--color-error-c6dbf459);
   --on-danger: var(--color-white-c6dbf459);
   --border: var(--color-secondary-c6dbf459);
+
+  /* Semantic below-threshold color (§ score states). A warm amber that reads as
+   * "almost there, not yet passing" and stays legible as a thick ring stroke /
+   * progress fill on BOTH the light (white) and dark (near-black) surfaces.
+   * One token, shared by both themes, so the ring + progress switch amber below
+   * the threshold and emerald at or above it from a single source of truth. */
+  --warn: 245, 158, 11; /* #F59E0B amber-500 */
+  --on-warn: 10, 10, 10;
+
+  /* Paper-shader wash color for the shell field (integrator-configurable via the
+   * PassportShell `washRgb` prop, which sets --rd-wash). Defaults to the accent
+   * so the living-material wash is on-brand emerald out of the box. */
+  --rd-wash: var(--accent);
+
+  /* Shell edge separation. A near-black widget on a DARK host would otherwise
+   * blend into it, so the shell carries its own soft light edge: a hairline
+   * light-alpha inner rim (a glass lip) plus a soft ambient outer glow. Both use
+   * a fixed white alpha so they read as separation on a dark host and simply
+   * fade to nothing on a light host (white glow over white is invisible) — never
+   * a hard outline (§no-hard-lines). Kept subtle and premium. Tokenized here so
+   * the values are single-sourced and re-tunable. */
+  --rd-edge-rim: inset 0 0 0 1px rgba(255, 255, 255, 0.09);
+  --rd-edge-glow:
+    0 0 0 0.5px rgba(255, 255, 255, 0.05),
+    0 6px 26px -2px rgba(255, 255, 255, 0.08);
 
   /* Width will be 300 unless screen
    * is too narrow, in which case it

--- a/test/utils/themes.test.tsx
+++ b/test/utils/themes.test.tsx
@@ -9,13 +9,13 @@ describe("Theme Utils", () => {
     it("includes all required color properties", () => {
       expect(DarkTheme.colors).toBeDefined();
       expect(DarkTheme.colors?.primary).toBe("255, 255, 255");
-      expect(DarkTheme.colors?.secondary).toBe("109, 109, 109");
-      expect(DarkTheme.colors?.background).toBe("0, 0, 0");
-      expect(DarkTheme.colors?.error).toBe("235, 48, 45");
+      expect(DarkTheme.colors?.secondary).toBe("115, 115, 115");
+      expect(DarkTheme.colors?.background).toBe("16, 24, 21");
+      expect(DarkTheme.colors?.error).toBe("252, 103, 100");
     });
 
     it("includes accent color for CTAs", () => {
-      expect(DarkTheme.colors?.accent).toBe("0, 212, 170"); // #00D4AA
+      expect(DarkTheme.colors?.accent).toBe("16, 185, 129"); // #10B981 Human Passport emerald
     });
 
     it("includes padding configuration", () => {
@@ -35,14 +35,14 @@ describe("Theme Utils", () => {
   describe("LightTheme", () => {
     it("includes all required color properties", () => {
       expect(LightTheme.colors).toBeDefined();
-      expect(LightTheme.colors?.primary).toBe("55, 55, 55");
-      expect(LightTheme.colors?.secondary).toBe("200, 200, 200");
+      expect(LightTheme.colors?.primary).toBe("10, 10, 10");
+      expect(LightTheme.colors?.secondary).toBe("115, 115, 115");
       expect(LightTheme.colors?.background).toBe("255, 255, 255");
-      expect(LightTheme.colors?.error).toBe("55, 55, 55");
+      expect(LightTheme.colors?.error).toBe("220, 38, 38");
     });
 
     it("includes accent color for CTAs", () => {
-      expect(LightTheme.colors?.accent).toBe("113, 248, 194"); // #71F8C2 - light theme accent
+      expect(LightTheme.colors?.accent).toBe("16, 185, 129"); // #10B981 Human Passport emerald
     });
 
     it("uses same padding as dark theme", () => {
@@ -106,10 +106,10 @@ describe("Widget setTheme functionality", () => {
 
     // Check all colors are applied
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("255, 255, 255");
-    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("109, 109, 109");
-    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("0, 0, 0");
-    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("0, 212, 170");
-    expect(style.getPropertyValue("--color-error-c6dbf459")).toBe("235, 48, 45");
+    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("115, 115, 115");
+    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("16, 24, 21");
+    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("16, 185, 129");
+    expect(style.getPropertyValue("--color-error-c6dbf459")).toBe("252, 103, 100");
   });
 
   it("handles missing accent color gracefully", () => {
@@ -177,7 +177,7 @@ describe("Widget setTheme functionality", () => {
     let style = window.getComputedStyle(widgetElement);
 
     // Initial theme
-    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("0, 212, 170");
+    expect(style.getPropertyValue("--color-accent-c6dbf459")).toBe("16, 185, 129");
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("255, 255, 255");
 
     // Real-world usage: spread existing theme and override specific values
@@ -202,8 +202,8 @@ describe("Widget setTheme functionality", () => {
     // Primary should be updated to dimmer white
     expect(style.getPropertyValue("--color-primary-c6dbf459")).toBe("230, 230, 230");
     // Other theme properties should remain from DarkTheme
-    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("0, 0, 0");
-    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("109, 109, 109");
+    expect(style.getPropertyValue("--color-background-c6dbf459")).toBe("16, 24, 21");
+    expect(style.getPropertyValue("--color-secondary-c6dbf459")).toBe("115, 115, 115");
   });
 
   it("handles theme with all properties defined", () => {


### PR DESCRIPTION
A design-SOP lint-and-fix pass over the redesign stamps grid + detail drawer. Storybook-first, both themes, everything audited against the [passport-embed](https://github.com/holonym-foundation/internal-docs/blob/main/products/passport/embed/design-sop.md) and [Shield](https://github.com/holonym-foundation/internal-docs/blob/main/products/shield/design-sop.md) design SOPs. No `main` / `PassportScoreWidget` changes. Icons stay monochrome `currentColor`. No em/en dashes. No gold/orange (emerald + neutral only; amber only for the below-threshold score ring and the tiny expiring indicator).

## Grid
1. **Tooltip overlap.** The shared `Tooltip` now renders its floating layer via `createPortal(document.body)`, so it escapes the shell's stacking context, is never occluded by the account row, and edge-flips / shifts against the viewport. Both themes.
2. **One indicator location = top-right.** The expiring amber dot moved from top-left to the top-right corner; it and the minted badge never render together, so the corner holds exactly one mark and there is no top-left indicator.
3. **Minted is self-evident + static.** Removed the confusing settle animation. Minted reads as a static emerald chain-link badge + glow ring.
4. **States legible + named.** The medallion tooltip states the status in words (Minted on-chain / Expiring in N days / Expired / Not yet on-chain / Not verified yet) above the description. The amber dot means "expiring" and is labeled.
5. **Clear category nav, no star pill.** Named tabs (Physical / Blockchain / Web2) with per-category counts, plus a plainly labeled overall summary ("N of M verified"). The ambiguous star + number pill is gone.

## Drawer (Shield accordion / fit pattern)
6. **Points shown once.** Header states the total; single-component stamps have no breakdown restating it; the redundant "how your points add up = {total}" caption is removed (the weighted bar carries no number).
7. **Multi-component accordion.** Civic's three components (Captcha 0.82 / Uniqueness 5.0 / Liveness 3.04) are all reachable and readable in a Score breakdown accordion, none clipped.
8. **Everything fits.** Accordion group (one section open at a time); the description yields when a section expands, so an open section always fits the fixed drawer height with the action row bottom-pinned. No clip, no scroll (verified via Playwright: action row within sheet bounds).
9. **Issued / Expires on one line.**
10. **Chain logo.** A monochrome Optimism mark leads "Onchain SBT · Optimism".
11. **Verified issuer.** Rendered as "Verified issuer" → human.tech (with a check + view-on-chain link), never raw hex. SBTs link the HubV3 contract; Clean Hands links the attester.
12. **Protocol label + link.** Clean Hands is a Sign Protocol attestation (not EAS): "Sign Protocol attestation" + "View on Sign Protocol" (`scan.sign.global/attestation/{id}`). SBTs: "Onchain SBT · Optimism" + view-on-chain to HubV3.
13. **Clean Hands privacy-accurate.** "Issued {date} · identity encrypted to the Human Network". No fabricated observer/signature; never renders the nullifier/indexingValue, user address, or PII.
14. **Integrated onchain block.** One coherent section (protocol/chain-logo · Issued/Expires · credential · verified issuer · status · view link).

## Validation
- `npx tsc --noEmit`, `yarn build-storybook`, `npx jest test/utils/themes.test.tsx` all green.
- No em/en dashes (grep clean).
- Headless Playwright (both themes): grid states legible, category tabs named + overall summary labeled, tooltip portaled to `document.body` and stating status, Civic accordion shows all three components with the action row inside the sheet (no clip/scroll), drawer fits, Sign Protocol label + "View on Sign Protocol" link present on Clean Hands, no hex/nullifier/observer/signature leaked in the drawer.

### SOP judgment calls
- **Single top-right slot:** minted takes priority over the expiring dot in the corner; a minted-and-expiring stamp still surfaces "Expiring in N days" via the tooltip and the drawer timer, so no meaning is lost and the corner is never crowded.
- **Description yields on expand:** to guarantee the fixed drawer height with an open accordion, the description hides while a section is expanded (Shield space-yielding pattern). Collapse a section to read it.
- **Optimism mark:** drawn monochrome (`currentColor`) from the OP logomark, paired with the "Optimism" label since the brand red cannot carry alone in a monochrome icon set.
- **Short tab names:** the long verbatim category names are abbreviated on the tabs (Physical / Blockchain / Web2) for 300px legibility; the verbatim name still shows in the category heading and every tab's accessible label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)